### PR TITLE
[NRC] Migrate dataset-configuration data set sections

### DIFF
--- a/src/data/dhis2-utils.ts
+++ b/src/data/dhis2-utils.ts
@@ -53,10 +53,13 @@ export async function getInChunks<T>(ids: Id[], getter: (idsGroup: Id[]) => Prom
     return _.flatten(objsCollection);
 }
 
-export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
-    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
+export function promiseMap<T, S>(
+    inputValues: T[],
+    mapper: (value: T, idx: number) => Promise<S>
+): Promise<S[]> {
+    const reducer = (acc$: Promise<S[]>, inputValue: T, idx: number): Promise<S[]> =>
         acc$.then((acc: S[]) =>
-            mapper(inputValue).then(result => {
+            mapper(inputValue, idx).then(result => {
                 acc.push(result);
                 return acc;
             })

--- a/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
+++ b/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
@@ -1,0 +1,153 @@
+import _ from "lodash";
+import { command, run } from "cmd-ts";
+import { getApiUrlOption, getD2Api } from "./common";
+import logger from "utils/log";
+import { promiseMap, runMetadata } from "data/dhis2-utils";
+import { D2Api, MetadataPick } from "types/d2-api";
+import { NamedRef } from "domain/entities/Base";
+import { Maybe } from "utils/ts-utils";
+
+export function runCli() {
+    const compareCmd = command({
+        name: "fix-sections-nrc-datasets",
+        description: "Fix NRC Data Set Configuration data sets after a core competencies rename",
+        args: { url: getApiUrlOption({ long: "url" }) },
+        handler: async args => {
+            const api = getD2Api(args.url);
+            const repo = new DataSetD2Repository(api);
+            new FixDataSetsAfterCoreCompetenciesRenameUseCase(repo).execute();
+        },
+    });
+
+    const args = process.argv.slice(2);
+    run(compareCmd, args);
+}
+
+runCli();
+
+class FixDataSetsAfterCoreCompetenciesRenameUseCase {
+    constructor(private dataSetsRepository: DataSetD2Repository) {}
+
+    async execute() {
+        const coreCompetenciesMapping = new Map([
+            ["SHELTER", "SHELTER & SETTLEMENTS"],
+            ["FOOD SECURITY", "LIVELIHOODS & FOOD SECURITY"],
+            ["CAMP MANAGEMENT", "PROTECTION FROM VIOLENCE"],
+        ]);
+
+        await this.dataSetsRepository.fix(coreCompetenciesMapping);
+    }
+}
+
+class DataSetD2Repository {
+    createdByAppAttributeCode = "GL_CREATED_BY_DATASET_CONFIGURATION";
+
+    constructor(private api: D2Api) {}
+
+    async fix(coreCompetenciesMapping: Map<string, string>) {
+        const dataSets = await this.getDataSets();
+        const coreCompetenciesByName = await this.getCoreCompetencies();
+        const sections = _.flatMap(dataSets, dataSet => dataSet.sections);
+
+        const sectionsFixed = _(sections)
+            .map(section => this.fixSection(section, coreCompetenciesByName, coreCompetenciesMapping))
+            .compact()
+            .value();
+
+        logger.info(`Core competencies: ${_.keys(coreCompetenciesByName).join(", ")}`);
+        logger.info(`Data sets: ${dataSets.length} - Sections: ${sections.length}`);
+        logger.info(`Sections to fix: ${sectionsFixed.length}`);
+
+        this.saveSections(sectionsFixed);
+    }
+
+    private saveSections(sections: D2Section[]) {
+        if (_.isEmpty(sections)) return;
+        const sectionsGroupList = _.chunk(sections, 100);
+
+        return promiseMap(sectionsGroupList, async (sectionsChunk, idx) => {
+            logger.info(
+                `POST ${sectionsChunk.length} sections (${JSON.stringify(sectionsChunk).length} bytes): ${
+                    idx + 1
+                }/${sectionsGroupList.length}`
+            );
+            const res = await runMetadata(this.api.metadata.post({ sections: sectionsChunk }));
+            logger.info(`Result: ${res.status} (${JSON.stringify(res.stats)})`);
+        });
+    }
+
+    private fixSection(
+        section: D2Section,
+        coreCompetenciesByName: CoreCompetenciesIndexedByName,
+        coreCompetenciesRenameMapping: RenameMapping
+    ): Maybe<D2Section> {
+        const match = section.name.match(/^(.*) (Outputs|Outcomes)$/);
+        const err = `Cannot match section: id='${section.id}' name='${section.name}'`;
+        if (!match) throw new Error(err);
+        const [sectionName, type] = match.slice(1);
+        if (!sectionName || !type) throw new Error(err);
+
+        const ccName = coreCompetenciesRenameMapping.get(sectionName) || sectionName;
+        const coreCompetency = coreCompetenciesByName[ccName];
+        logger.debug(`section ${section.id} (${section.name}): sectionName=${sectionName}, type=${type}`);
+        if (!coreCompetency) throw new Error(`Core competency (DEGroup) not found: name='${ccName}'`);
+
+        const name = [coreCompetency.name, type].join(" ");
+        const code = [section.dataSet.id, type.toUpperCase(), coreCompetency.code].join("_");
+        const sectionFixed: D2Section = { ...section, name: name, code: code };
+        return _.isEqual(section, sectionFixed) ? undefined : sectionFixed;
+    }
+
+    private async getCoreCompetencies(): Promise<Record<Name, CoreCompetency>> {
+        const { dataElementGroupSets } = await this.api.metadata
+            .get({
+                dataElementGroupSets: {
+                    fields: {
+                        id: true,
+                        code: true,
+                        dataElementGroups: { id: true, code: true, name: true },
+                    },
+                    filter: { code: { eq: "GL_CoreComp_DEGROUPSET" } },
+                },
+            })
+            .getData();
+
+        const coreCompetencySet = dataElementGroupSets[0];
+        if (!coreCompetencySet) throw new Error("Cannot get dataElementGroupSet");
+
+        return _.keyBy(coreCompetencySet.dataElementGroups, deg => deg.name);
+    }
+
+    private async getDataSets(): Promise<D2DataSet[]> {
+        const { dataSets } = await this.api.metadata.get(metadataQuery).getData();
+
+        return dataSets.filter(dataSet =>
+            dataSet.attributeValues.some(
+                av => av.attribute.code === this.createdByAppAttributeCode && av.value === "true"
+            )
+        );
+    }
+}
+
+const metadataQuery = {
+    dataSets: {
+        fields: {
+            attributeValues: { value: true, attribute: { code: true } },
+            sections: { $owner: true, greyedFields: { $owner: true } },
+        },
+    },
+} as const;
+
+interface CoreCompetency extends NamedRef {
+    code: string;
+}
+
+type Name = string;
+
+type CoreCompetenciesIndexedByName = Record<Name, CoreCompetency>;
+
+type RenameMapping = Map<string, string>;
+
+type D2DataSet = MetadataPick<typeof metadataQuery>["dataSets"][number];
+
+type D2Section = D2DataSet["sections"][number];

--- a/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
+++ b/src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts
@@ -63,14 +63,15 @@ class DataSetD2Repository {
 
     private saveSections(sections: D2Section[]) {
         if (_.isEmpty(sections)) return;
-        const sectionsGroupList = _.chunk(sections, 100);
+
+        const sectionsGroupList = _(sections)
+            .sortBy(section => section.greyedFields.length)
+            .reverse()
+            .chunk(10)
+            .value();
 
         return promiseMap(sectionsGroupList, async (sectionsChunk, idx) => {
-            logger.info(
-                `POST ${sectionsChunk.length} sections (${JSON.stringify(sectionsChunk).length} bytes): ${
-                    idx + 1
-                }/${sectionsGroupList.length}`
-            );
+            logger.info(`POST ${sectionsChunk.length} sections: ${idx + 1}/${sectionsGroupList.length}`);
             const res = await runMetadata(this.api.metadata.post({ sections: sectionsChunk }));
             logger.info(`Result: ${res.status} (${JSON.stringify(res.stats)})`);
         });


### PR DESCRIPTION
[DON'T MERGE] Close PR when task performed

Closes https://app.clickup.com/t/865c48cuk

- [x] Execute against PRO (by client)
- [x] Install app in PrO

Steps:

```
$ # Make a backup of database.
$ git clone https://github.com/EyeSeeTea/d2-tools
$ cd d2-tools
$ git checkout feature/nrc-ds-config-datasets-migration
$ nvm use v16.14.0
$ yarn install
$ npx ts-node src/scripts/nrc-ds-config-migrate-dataset-sections-codes.ts --url="https://USER:PASSWORD@gors.nrc.no"
```

Notes: 

- _USER_ must have permission to get and update data sets. 
-  Both _USER_ and _PASSWORD_ must be URL-encoded (for example, a `@` should be written as `%40`).  This online service can be used to transform the fields (note:  the separator `:` must be left as-is): https://www.freeformatter.com/url-encoder.html#before-output -> write the user or password and then click `[URL Encode]`.

Warnings:

- In some of the executions, I got "Batch update returned unexpected row count from update" error from the API. This happens when the section is being updated also in the UI. That's not a problem, just run the script again. The script can be run many times as desired, it will update only the required dataset sections. 
- The payload has reduced to the minimum, and the chunks reduce to 10 sections to avoid payload size problems (that we found in gorsdev for chunk=100. The max payload size depends not on DHIS2 but the web server -nginx, Apache- over it).