### PR TITLE
[đix] Remove duplicated TEI id option

### DIFF
--- a/src/data/d2-program-rules/D2ProgramRules.ts
+++ b/src/data/d2-program-rules/D2ProgramRules.ts
@@ -488,7 +488,6 @@ export class D2ProgramRules {
                     programStartDate: startDate,
                     trackedEntityInstance: teiId,
                     programEndDate: endDate,
-                    trackedEntityInstance: runOptions.teiId,
                     totalPages: true,
                     page: page,
                     pageSize: pageSize,


### PR DESCRIPTION
Duplicated trackedEntityInstance, probably result of automatic git merge.