### PR TITLE
Feature/ignore invalid users

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,9 +448,9 @@ A config json file to get the user/password and server:
 
 d2-tools -> two-factor-monitoring:
 
-A program id with the id of the program in dhis
+A push program variable with the id of the program in dhis
 
-A group id to filter the users that should have two factor activated
+A two factor group to filter the users that should have two factor activated
 
 The datastore must contain:
 
@@ -486,19 +486,19 @@ List of excluded users (the script will ignore them) (could be an empty list [])
 A minimum group to add that group to the users without any template group (WIDP requirement)
 
 A minimum role to add that role to the users without any role (DHIS requirement)
-A push_program_id variable with the program ID to send the report
+A pushProgram variable with the program ID to send the report
 
 A list of templates (user with the valid roles, and group to identify which users could use those roles).
 
 A list with flags to control the script (permissionFixerConfig).
 
-A boolean variable push_report to determine if the script must send the report after processing all users
+The pushReport boolean variable determines whether the script should send the report after processing all users.
 
-A boolean variable pushFixedUserGroups to allow push the fixed usergroups (for those users without widp template user group)
+The pushFixedUserGroups boolean variable enables pushing fixed user groups for users who do not have a WIDP template user group.
 
-A boolean variable pushFixedUsersRoles to allow the push of the fixed users.
+The pushFixedUsersRoles boolean variable allows the pushing of fixed user roles.
 
-A boolean variable forceMinimalGroupForUsersWithoutGroup to determine ignore the users with invalid usergroup exception, assuming for that users the minimal group
+The forceMinimalGroupForUsersWithoutGroup boolean variable determines how to handle users with invalid user groups. If set to true, it treats these users as if they are assigned to the minimal group without updating their user group. If set to false, it assigns the minimal group to users without a template user group on the server.
 
 An example of the datastore:
 

--- a/README.md
+++ b/README.md
@@ -486,14 +486,19 @@ List of excluded users (the script will ignore them) (could be an empty list [])
 A minimum group to add that group to the users without any template group (WIDP requirement)
 
 A minimum role to add that role to the users without any role (DHIS requirement)
-
-A boolean variable push_report to determine if the script must send the report after processing all users
-
 A push_program_id variable with the program ID to send the report
 
 A list of templates (user with the valid roles, and group to identify which users could use those roles).
 
 A list with flags to control the script (permissionFixerConfig).
+
+A boolean variable push_report to determine if the script must send the report after processing all users
+
+A boolean variable pushFixedUserGroups to allow push the fixed usergroups (for those users without widp template user group)
+
+A boolean variable pushFixedUsersRoles to allow the push of the fixed users.
+
+A boolean variable forceMinimalGroupForUsersWithoutGroup to determine ignore the users with invalid usergroup exception, assuming for that users the minimal group
 
 An example of the datastore:
 
@@ -558,6 +563,7 @@ Note: the names are used only to make easy understand and debug the keys.
     "name": "Role name"
   },
   "permissionFixerConfig":{
+    "forceMinimalGroupForUsersWithoutGroup": true,
     "pushFixedUserGroups": false,
     "pushFixedUsersRoles": false,
     "pushReport": true

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -71,27 +71,24 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
         );
 
         if (response?.status != "OK") {
-            await this.saveUserErrorsOnLogFile(responseRoles.userProcessed);
+            this.saveUserErrorsOnLogFile(responseRoles.userProcessed);
             throw new Error("Error on push report: " + JSON.stringify(response));
         } else {
             return response.status;
         }
     }
 
-    private async saveUserErrorsOnLogFile(userActionRequired: UserMonitoringUserResponse[]) {
+    private saveUserErrorsOnLogFile(userActionRequired: UserMonitoringUserResponse[]) {
         const userToPost: PermissionFixerUser[] = userActionRequired.map(item => {
             return item.fixedUser;
         });
         log.error(`Save jsons on import error: ${filenameErrorOnPush}`);
-        await UserMonitoringFileResourceUtils.saveInJsonFormat(
+        UserMonitoringFileResourceUtils.saveInJsonFormat(
             JSON.stringify({ userToPost }, null, 4),
             filenameErrorOnPush
         );
         log.error(`Save errors in csv: `);
-        await UserMonitoringFileResourceUtils.savePermissionFixerToCsv(
-            userActionRequired,
-            `${csvErrorFilename}`
-        );
+        UserMonitoringFileResourceUtils.savePermissionFixerToCsv(userActionRequired, `${csvErrorFilename}`);
     }
 
     private async pushReportToDhis(

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -70,14 +70,14 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
         );
 
         if (response?.status != "OK") {
-            this.saveUserErrorsOnLogFile(responseRoles.userProcessed);
+            await this.saveUserErrorsOnLogFile(responseRoles.userProcessed);
             throw new Error("Error on push report: " + JSON.stringify(response));
         } else {
             return response.status;
         }
     }
 
-    private saveUserErrorsOnLogFile(userActionRequired: UserMonitoringUserResponse[]) {
+    private async saveUserErrorsOnLogFile(userActionRequired: UserMonitoringUserResponse[]) {
         const userToPost: PermissionFixerUser[] = userActionRequired.map(item => {
             return item.fixedUser;
         });
@@ -87,7 +87,10 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             filenameErrorOnPush
         );
         log.error(`Save errors in csv: `);
-        UserMonitoringFileResourceUtils.savePermissionFixerToCsv(userActionRequired, `${csvErrorFilename}`);
+        await UserMonitoringFileResourceUtils.savePermissionFixerToCsv(
+            userActionRequired,
+            `${csvErrorFilename}`
+        );
     }
 
     private async pushReportToDhis(

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -1,4 +1,3 @@
-import { FileUploadParameters, Files } from "@eyeseetea/d2-api/api/files";
 import { D2Api } from "types/d2-api";
 import log from "utils/log";
 import _ from "lodash";

--- a/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerConfigOptions.ts
+++ b/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerConfigOptions.ts
@@ -21,4 +21,5 @@ export interface PermissionFixerConfig {
     pushReport: boolean;
     pushFixedUsersRoles: boolean;
     pushFixedUserGroups: boolean;
+    forceMinimalGroupForUsersWithoutGroup: boolean;
 }

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -102,7 +102,26 @@ export class RunUserPermissionUseCase {
             log.info(`Nothing to report. No invalid users found.`);
         }
     }
-
+    private preProcessUsers(
+        allUsers: PermissionFixerUser[],
+        completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
+        forceMinimalGroupForUsersWithoutGroup: boolean,
+        minimalGroupId: string
+    ) {
+        if (forceMinimalGroupForUsersWithoutGroup) {
+            log.info(
+                "forceMinimalGroupForUsersWithoutGroup is enabled. Adding minimal group to users without group."
+            );
+            const usersWithForcedMinimalGroup = this.addMinimalUserGroupToUsersWithoutUserGroup(
+                allUsers,
+                completeTemplateGroups,
+                minimalGroupId
+            );
+            return usersWithForcedMinimalGroup;
+        } else {
+            return allUsers;
+        }
+    }
     async processUserRoles(
         options: PermissionFixerMetadataConfig,
         completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
@@ -117,20 +136,16 @@ export class RunUserPermissionUseCase {
             excludedRolesByGroup,
         } = options;
 
-        log.info("Processing users...");
-        if (forceMinimalGroupForUsersWithoutGroup) {
-            log.info(
-                "forceMinimalGroupForUsersWithoutGroup is enabled. Adding minimal group to users without group."
-            );
-            this.addMinimalUserGroupToUsersWithoutUserGroup(
-                allUsers,
-                completeTemplateGroups,
-                minimalGroup.id
-            );
-        }
-        this.validateUsers(allUsers, completeTemplateGroups, minimalGroup.id);
-        const userinfo: UserMonitoringUserResponse[] = this.processUsers(
+        const allPreProcessedUsers = this.preProcessUsers(
             allUsers,
+            completeTemplateGroups,
+            forceMinimalGroupForUsersWithoutGroup,
+            minimalGroup.id
+        );
+
+        this.validateUsers(allPreProcessedUsers, completeTemplateGroups, minimalGroup.id);
+        const userinfo: UserMonitoringUserResponse[] = this.processUsers(
+            allPreProcessedUsers,
             completeTemplateGroups,
             excludedRolesByRole,
             excludedRolesByGroup,
@@ -196,6 +211,7 @@ export class RunUserPermissionUseCase {
         excludedRolesByUser: RolesByUser[],
         minimalRole: Ref
     ): UserMonitoringUserResponse[] {
+        log.info("Processing users...");
         const processedUsers = _.compact(
             allUsers.map(user => {
                 const templateGroupMatch = completeTemplateGroups.find(template => {
@@ -336,17 +352,25 @@ export class RunUserPermissionUseCase {
         allUsers: PermissionFixerUser[],
         completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
         minimalGroupId: string
-    ) {
-        allUsers.map(user => {
-            const templateGroupMatch = completeTemplateGroups.find(template => {
-                return user.userGroups.some(
-                    userGroup => userGroup != undefined && template.group.id == userGroup.id
-                );
-            });
+    ): PermissionFixerUser[] {
+        return allUsers.map(user => {
+            const templateGroupMatch = this.findTemplateGroupMatch(completeTemplateGroups, user);
             if (templateGroupMatch == undefined) {
                 //template not found -> all roles are invalid except the minimal role
                 user.userGroups.push({ id: minimalGroupId, name: "Minimal Group" });
             }
+            return { ...user };
+        });
+    }
+
+    private findTemplateGroupMatch(
+        completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
+        user: PermissionFixerUser
+    ) {
+        return completeTemplateGroups.find(template => {
+            return user.userGroups.some(
+                userGroup => userGroup != undefined && template.group.id == userGroup.id
+            );
         });
     }
 
@@ -355,12 +379,9 @@ export class RunUserPermissionUseCase {
         completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
         minimalGroupId: string
     ) {
+        log.info("Validating users...");
         allUsers.map(user => {
-            const templateGroupMatch = completeTemplateGroups.find(template => {
-                return user.userGroups.some(
-                    userGroup => userGroup != undefined && template.group.id == userGroup.id
-                );
-            });
+            const templateGroupMatch = this.findTemplateGroupMatch(completeTemplateGroups, user);
             if (templateGroupMatch == undefined) {
                 //template not found -> all roles are invalid except the minimal role
                 log.error(

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -102,6 +102,7 @@ export class RunUserPermissionUseCase {
             log.info(`Nothing to report. No invalid users found.`);
         }
     }
+
     private preProcessUsers(
         allUsers: PermissionFixerUser[],
         completeTemplateGroups: PermissionFixerTemplateGroupExtended[],
@@ -122,6 +123,7 @@ export class RunUserPermissionUseCase {
             return allUsers;
         }
     }
+
     async processUserRoles(
         options: PermissionFixerMetadataConfig,
         completeTemplateGroups: PermissionFixerTemplateGroupExtended[],


### PR DESCRIPTION
Added new boolean variable in the datastore to avoid the push of the report without fix before the usergroups.

The script assume that the user has a valid usergroup adding the minimal usergroup to that users without any valid usergroup, to allow to the report continue.

forceMinimalGroupForUsersWithoutGroup