### PR TITLE
Added new field twoFactorEnabled

### DIFF
--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -19,10 +19,11 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
             )
             .getData();
         return responses["users"].map(user => {
+            const twoFA = user.userCredentials.twoFA || user.userCredentials.twoFactorEnabled;
             return {
                 id: user.id,
                 username: user.username,
-                twoFA: user.twoFA,
+                twoFA: twoFA ?? false,
             };
         });
     }

--- a/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerUser.ts
+++ b/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerUser.ts
@@ -33,6 +33,7 @@ export interface PermissionFixerUserCredentials {
     uid: Id;
     disabled: boolean;
     twoFA: boolean;
+    twoFactorEnabled: boolean;
     username: string;
     userRoles: NamedRef[];
 }


### PR DESCRIPTION
2.41 has changed the field twoFA by twoFactorEnabled in the api.

This PR fix that probnlem in our script to identify users with twofa enabled

How execute it?
yarn start usermonitoring run-2fa-reporter --config-file config.json
Detailed information in the readme

And then you can find the event in capture-> ou global program: ADMIN_Users_Check(Event)

I test it in dev and dev-cont to check that still working for both versions 2.38 and 2.41