### PR TITLE
Feature/fix usergroup update

### DIFF
--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -1,4 +1,4 @@
-import { D2Api, D2ApiResponse, Stats } from "@eyeseetea/d2-api/2.36";
+import { D2Api, Stats } from "@eyeseetea/d2-api/2.36";
 import log from "utils/log";
 import { PermissionFixerUserGroupExtended } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUserGroupExtended";
 import { PermissionFixerUserGroupRepository } from "domain/repositories/user-monitoring/permission-fixer/PermissionFixerUserGroupRepository";

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -1,9 +1,10 @@
-import { D2Api } from "@eyeseetea/d2-api/2.36";
+import { D2Api, D2ApiResponse, Stats } from "@eyeseetea/d2-api/2.36";
 import log from "utils/log";
 import { PermissionFixerUserGroupExtended } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUserGroupExtended";
 import { PermissionFixerUserGroupRepository } from "domain/repositories/user-monitoring/permission-fixer/PermissionFixerUserGroupRepository";
 import { Async } from "domain/entities/Async";
 import { UserGroupNotFoundException } from "./exception/UserGroupNotFoundException";
+import { Id, Ref } from "domain/entities/Base";
 
 export class PermissionFixerUserGroupD2Repository implements PermissionFixerUserGroupRepository {
     constructor(private api: D2Api) {}
@@ -23,21 +24,45 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
             throw new UserGroupNotFoundException("Error getting user group: " + groupsIds);
         }
     }
-    async save(userGroup: PermissionFixerUserGroupExtended): Async<string> {
+    async save(userGroup: PermissionFixerUserGroupExtended, users: Ref[]): Async<string> {
         try {
-            const response = await this.api.models.userGroups.put(userGroup).getData();
-            if (response.status == "OK") {
+            const response = await this.appendUsersInUsergroup(userGroup, users);
+            if (response == "OK") {
                 log.info("Users added to minimal group");
             } else {
                 log.error("Error adding users to minimal group");
             }
 
-            log.info(JSON.stringify(response.response));
+            log.info(JSON.stringify(response));
 
-            return response.status;
+            return response;
         } catch (error) {
             console.debug(error);
             return "ERROR";
         }
     }
+
+    private async appendUsersInUsergroup(
+        userGroup: PermissionFixerUserGroupExtended,
+        users: Ref[]
+    ): Async<string> {
+        const usersIds = users.map(({ id }) => ({ id: id }));
+        const response = await this.api
+            .post<UserGroupResponse>(
+                `/userGroups/${userGroup.id}/users/`,
+                { async: false },
+                {
+                    additions: usersIds,
+                }
+            )
+            .getData();
+        log.info(response.status);
+        return response.status;
+    }
 }
+
+type UserGroupResponse = {
+    status: string;
+    typeReports: object[];
+    stats: Stats;
+};

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -4,7 +4,7 @@ import { PermissionFixerUserGroupExtended } from "domain/entities/user-monitorin
 import { PermissionFixerUserGroupRepository } from "domain/repositories/user-monitoring/permission-fixer/PermissionFixerUserGroupRepository";
 import { Async } from "domain/entities/Async";
 import { UserGroupNotFoundException } from "./exception/UserGroupNotFoundException";
-import { Id, Ref } from "domain/entities/Base";
+import { Ref } from "domain/entities/Base";
 
 export class PermissionFixerUserGroupD2Repository implements PermissionFixerUserGroupRepository {
     constructor(private api: D2Api) {}
@@ -26,7 +26,7 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
     }
     async save(userGroup: PermissionFixerUserGroupExtended, users: Ref[]): Async<string> {
         try {
-            const response = await this.appendUsersInUsergroup(userGroup, users);
+            const response = await this.appendUsersToUsergroup(userGroup, users);
             if (response == "OK") {
                 log.info("Users added to minimal group");
             } else {
@@ -42,7 +42,7 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
         }
     }
 
-    private async appendUsersInUsergroup(
+    private async appendUsersToUsergroup(
         userGroup: PermissionFixerUserGroupExtended,
         users: Ref[]
     ): Async<string> {
@@ -50,7 +50,7 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
         const response = await this.api
             .post<UserGroupResponse>(
                 `/userGroups/${userGroup.id}/users/`,
-                { async: false },
+                {},
                 {
                     additions: usersIds,
                 }

--- a/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerUserGroupRepository.ts
+++ b/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerUserGroupRepository.ts
@@ -1,8 +1,8 @@
 import { Async } from "domain/entities/Async";
-import { Id } from "domain/entities/Base";
+import { Id, Ref } from "domain/entities/Base";
 import { PermissionFixerUserGroupExtended } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUserGroupExtended";
 
 export interface PermissionFixerUserGroupRepository {
     get(ids: Id): Async<PermissionFixerUserGroupExtended>;
-    save(userGroup: PermissionFixerUserGroupExtended): Async<string>;
+    save(userGroup: PermissionFixerUserGroupExtended, users: Ref[]): Async<string>;
 }

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -466,7 +466,6 @@ export class RunUserPermissionUseCase {
             const userIds = userIdWithoutGroups.map(item => {
                 return { id: item.id };
             });
-            minimalUserGroup.users.push(...userIds);
 
             log.info("Pushing fixed users without groups");
             if (!pushFixedUserGroups) {
@@ -477,7 +476,7 @@ export class RunUserPermissionUseCase {
                 );
             }
 
-            const response = await this.userGroupRepository.save(minimalUserGroup);
+            const response = await this.userGroupRepository.save(minimalUserGroup, userIds);
             return this.getResponse(response, userIdWithoutGroups.length, userIdWithoutGroups);
         } else {
             return this.getResponse("No users without groups found.", 0, []);


### PR DESCRIPTION
…usergroup

User permission fixer was adding to the WIDP USERS group all the users without group. But was overriding the userGroup sharing settings, also was using the endpoint that broke our instances.

I have changed from post the full userGroup to addition in the usergroup the missing users

 I tested it in a local instance using:
 yarn  start usermonitoring run-permissions-fixer --config-file config.json
 