### PR TITLE
fix: order id does not work for v40, use trackedEntity

### DIFF
--- a/src/data/d2-program-rules/D2ProgramRules.ts
+++ b/src/data/d2-program-rules/D2ProgramRules.ts
@@ -481,7 +481,7 @@ export class D2ProgramRules {
             const res = await getData(
                 this.api.trackedEntityInstances.get({
                     program: program.id,
-                    order: "id:asc",
+                    order: "trackedEntity:asc",
                     ...orgUnitsFilter,
                     fields: "*,enrollments[events]",
                     programStartDate: startDate,


### PR DESCRIPTION
Required by https://app.clickup.com/t/8697re7wv

Otherwise, for v40:

```
$ curl-msf 'http://localhost:8097/api/trackedEntityInstances?program=ORvg6A5ed7z&ouMode=ALL&order=id:asc' | jq .message
"Invalid order property: id"```