### PR TITLE
Add README entry for  the enrollment status script, minor comparison method update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,7 +1003,7 @@ yarn start data get-report \
 ### Close Enrollments with Events older than a date
 
 Set the status to completed for all enrollments that satisfy the following criteria:
-- All _events_ have an _event date_ older or equal to the cut off date.
+- All their _events_ have an _event date_ older than the cut off date.
 - The _enrollment_ belong to the selected _organization unit_ and _program_.
 
 The date can have either `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss` format. If no time is specified 00:00:00 is used.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,54 @@ LOG_LEVEL=debug yarn start datasets
 
 Available levels: 'debug' | 'info' | 'warn' | 'error'
 
+## Tools index
+
+-   [Execute Program Rules](#execute-program-rules)
+-   [Programs export/import](#programs-exportimport)
+-   [Datasets](#datasets)
+    -   [Compare pairs of data sets](#compare-pairs-of-data-sets)
+    -   [Compare pairs of data sets between two instances](#compare-pairs-of-data-sets-between-two-instances)
+    -   [Show the schema fields used on the comparison](#show-the-schema-fields-used-on-the-comparison)
+    -   [Compare two data sets ignoring some of the properties](#compare-two-data-sets-ignoring-some-of-the-properties)
+-   [Organisation Units](#organisation-units)
+    -   [Create an SQL file to remove any orgunit below the country level](#create-an-sql-file-to-remove-any-orgunit-below-the-country-level)
+    -   [Create an SQL file to remove all org subunits of Canada](#create-an-sql-file-to-remove-all-org-subunits-of-canada)
+    -   [Copy the organisation units from a data set to one or more datasets](#copy-the-organisation-units-from-a-data-set-to-one-or-more-datasets)
+-   [Translations](#translations)
+-   [Events](#events)
+    -   [Move events from one orgunit to another](#move-events-from-one-orgunit-to-another)
+    -   [Update events which met the condition](#update-events-which-met-the-condition)
+-   [Data values](#data-values)
+    -   [Dangling data values](#dangling-data-values)
+    -   [Revert data values](#revert-data-values)
+    -   [Delete duplicated event data values](#delete-duplicated-event-data-values)
+    -   [Email notification for data values](#email-notification-for-data-values)
+-   [Notifications](#notifications)
+    -   [Send user info email](#send-user-info-email)
+-   [Load testing](#load-testing)
+-   [Users](#users)
+    -   [Migrate user information from one attribute to another if they're different](#migrate-user-information-from-one-attribute-to-another-if-theyre-different)
+    -   [Rename username](#rename-username)
+-   [User monitoring](#user-monitoring)
+    -   [Users Permissions Fixer and 2FA Reporter](#users-permissions-fixer-and-2fa-reporter)
+    -   [Users Authorities Monitoring](#users-authorities-monitoring)
+    -   [User Groups Monitoring](#user-groups-monitoring)
+    -   [User Templates Monitoring](#user-templates-monitoring)
+-   [Move Attributes from a Program](#move-attributes-from-a-program)
+-   [Compare metadata between instances](#compare-metadata-between-instances)
+-   [Indicators](#indicators)
+    -   [Get Indicators items report](#get-indicators-items-report)
+    -   [Get Indicators dataElements values report](#get-indicators-dataelements-values-report)
+-   [Tracked Entities](#tracked-entities)
+    -   [Transfer](#transfer)
+-   [Options](#options)
+    -   [Rename](#rename)
+-   [Data](#data)
+    -   [Get report](#get-report)
+-   [Enrollments](#enrollments)
+    -   [Close Enrollments with Events older than a date](#close-enrollments-with-events-older-than-a-date)
+
+
 ## Execute Program Rules
 
 Create report and post events or tracked entity attributes:
@@ -948,4 +996,34 @@ yarn start data get-report \
     --url="https://play.im.dhis2.org/dev" \
     --auth="admin:district" \
     --orgunit-id="DiszpKrYNg8"
+```
+
+## Enrollments
+
+### Close Enrollments with Events older than a date
+
+Set the status to completed for all enrollments that satisfy the following criteria:
+- All _events_ have an _event date_ older or equal to the cut off date.
+- The _enrollment_ belong to the selected _organization unit_ and _program_.
+
+The date can have either `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss` format. If no time is specified 00:00:00 is used.
+
+If some of the enrollments could not be closed their info is stored in a `close_errors_<timestamp>.json` file.
+
+```console
+shell:~$ yarn start enrollments close \
+  --url 'http://USER:PASSWORD@localhost:8080' \
+  --org-unit-id 'DiszpKrYNg8' \
+  --program-id 'WCJhvPcJomX' \
+  --event-date-before "2025-01-01T00:00:00"
+```
+
+To get the debug log use:
+
+```console
+shell:~$ LOG_LEVEL=debug yarn start enrollments close \
+  --url 'http://USER:PASSWORD@localhost:8080' \
+  --org-unit-id 'DiszpKrYNg8' \
+  --program-id 'WCJhvPcJomX' \
+  --event-date-before "2025-01-01T00:00:00"
 ```

--- a/src/domain/usecases/enrollments/CloseEnrollmentsUseCase.ts
+++ b/src/domain/usecases/enrollments/CloseEnrollmentsUseCase.ts
@@ -45,7 +45,7 @@ export class CloseEnrollmentsUseCase {
         const cutoffDate = new Date(params.eventUpdateCutoff);
         const eventsInCutoffRange = newestEventByEnrollment.filter(event => {
             const eventDate = new Date(event.occurredAt);
-            return eventDate <= cutoffDate;
+            return eventDate < cutoffDate;
         });
 
         log.info(`Found ${eventsInCutoffRange.length} events before or at the provided date`);

--- a/src/scripts/commands/enrollments.ts
+++ b/src/scripts/commands/enrollments.ts
@@ -18,8 +18,9 @@ export function getCommand() {
 const closeEnrollmentsCmd = command({
     name: "close",
     description: [
-        "Close enrollments for events that have been updated before a certain date. An orgunit, program and date must be provided.",
-        "If there are errors the relevant enrollments will be logged into a JSON file.",
+        "Set the status to completed for all enrollments whose events have an event date older than the cut off date.",
+        "An orgunit, program and date must be provided.",
+        "If there are errors the relevant enrollments will be logged into a close_errors_<timestamp>.json file.",
     ].join("\n"),
     args: {
         url: getApiUrlOption({ long: "url" }),


### PR DESCRIPTION
- Updated README and script help message.
- Added a index to the README with each tool link
- Made the cutoff date comparison a lower than instead of lower or equal.
  This is to make it easier to cut off events, as they generally have a `YYYY-MM-DDT00:00:00` event date, thus needing to use `YYYY-MM-DD-1T23:59:59` cutoff dates to close enrollments with events before YYYY-MM-DD with the old comparison.