### PR TITLE
Fix twofactor user groups report Feature/add twofactor new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,9 +539,17 @@ A config json file to get the user/password and server:
 
 d2-tools -> two-factor-monitoring:
 
-A push program variable with the id of the program in dhis
+A pushProgram variable with the ID of the program in DHIS2 used to track user account checks.
 
-A two factor group to filter the users that should have two factor activated
+A twoFactorGroup to filter the active users that are expected to have two-factor authentication (2FA) enabled.
+
+A whoAccountGroup to filter the users that are expected to have a valid WHO account (WIMS). Users not in this group will be flagged as having an incorrect WHO setup.
+
+An exceptionGroup list containing groups whose users should be excluded from validation checks — even if they are missing 2FA or WHO account membership.
+
+An optional --disable-users CLI flag that, when passed, will disable users identified as invalid due to missing or disabled 2FA.
+
+
 
 The datastore must contain:
 
@@ -554,9 +562,20 @@ The datastore must contain:
     "twoFactorGroup": {
         "id": "uid",
         "name": "Auth control group"
-    }
+    },
+    "whoAccountGroup": {
+    "id": "zjeqEiv9Ept",
+    "name": "WIDP Who Auth"
+    },
+    "exceptionGroup": [
+      {
+        "id": "HASUnoSNcSA",
+        "name": "user-scripts"
+      }
+    ]
 }
 ```
+
 
 #### run-users-monitoring Datastore:
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "author": "EyeSeeTea <arnau@eyeseetea.com>",
     "license": "MIT",
     "dependencies": {
-        "@eyeseetea/d2-api": "1.18.0-beta.3",
+        "@eyeseetea/d2-api": "1.18.0-beta.7",
         "@types/json-diff": "^0.7.0",
         "async-parallel": "^1.2.3",
         "cmd-ts": "^0.10.0",

--- a/src/data/externalConfig/Namespaces.ts
+++ b/src/data/externalConfig/Namespaces.ts
@@ -1,6 +1,6 @@
 export const d2ToolsNamespace = "d2-tools";
 
-export type Namespace = (typeof Namespace)[keyof typeof Namespace];
+export type Namespace = typeof Namespace[keyof typeof Namespace];
 
 export const Namespace = {
     PERMISSION_FIXER: "permission-fixer",

--- a/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
+++ b/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
@@ -10,19 +10,20 @@ import { UserMonitoringUserResponse } from "domain/entities/user-monitoring/comm
 export class UserMonitoringFileResourceUtils {
     //This method only works right when you build the application using nvm use 16
     static async saveFileResource(jsonString: string, name: string, api: D2Api): Async<string> {
+        const uniqueFilename = this.createUniqueFilename(name);
+        log.info(`Saving file ${uniqueFilename}`);
         const jsonBlob = Buffer.from(jsonString, "utf-8");
         if (jsonBlob.length === 0){
-            return "Error: The file is empty. Please provide a valid file content.";
+            log.info("The file is empty.");
+            return "";
         }
         const files = new Files(api);
-        const uniqueFilename = this.createUniqueFilename(name);
         const form: FileUploadParameters = {
             name: uniqueFilename,
             data: jsonBlob,
             ignoreDocument: true,
             domain: "DATA_VALUE",
         };
-        log.info(`Saving file ${uniqueFilename}`);
         const response = await files.saveFileResource(form).getData();
         const fileresourceId = response;
         return fileresourceId;

--- a/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
+++ b/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
@@ -11,7 +11,9 @@ export class UserMonitoringFileResourceUtils {
     //This method only works right when you build the application using nvm use 16
     static async saveFileResource(jsonString: string, name: string, api: D2Api): Async<string> {
         const jsonBlob = Buffer.from(jsonString, "utf-8");
-
+        if (jsonBlob.length === 0){
+            return "Error: The file is empty. Please provide a valid file content.";
+        }
         const files = new Files(api);
         const uniqueFilename = this.createUniqueFilename(name);
         const form: FileUploadParameters = {

--- a/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
+++ b/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
@@ -13,7 +13,7 @@ export class UserMonitoringFileResourceUtils {
         const uniqueFilename = this.createUniqueFilename(name);
         log.info(`Saving file ${uniqueFilename}`);
         const jsonBlob = Buffer.from(jsonString, "utf-8");
-        if (jsonBlob.length === 0){
+        if (jsonBlob.length === 0) {
             log.info("The file is empty.");
             return "";
         }

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
@@ -21,31 +21,23 @@ type ServerResponse = { status: string; typeReports: object[] };
 export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
     constructor(private api: D2Api) {}
     async save(program: UserMonitoringProgramMetadata, report: TwoFactorUserReport): Async<string> {
+        const invalidTwoFAList = this.formatUsers(report.invalidTwoFAList);
+        const invalidWhoList = this.formatUsers(report.invalidWhoList);
+        const invalidAuthList = this.formatUsers(report.invalidAuthList);
+        
         const twoFactorUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
-            report.invalidTwoFAList
-                .map(user => {
-                    return user.name + "," + user.id;
-                })
-                .join("\n"),
+            invalidTwoFAList,
             "_twoFa"+filenameUserReported,
             this.api
         );
 
         const whoAccountUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
-            report.invalidWhoList
-                .map(user => {
-                    return user.name + "," + user.id;
-                })
-                .join("\n"),
+            invalidWhoList,
             "_who"+filenameUserReported,
             this.api
         );
         const invalidUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
-            report.invalidAuthList
-                .map(user => {
-                    return user.name + "," + user.id;
-                })
-                .join("\n"),
+            invalidAuthList,
             "_invalid"+filenameUserReported,
             this.api
         );
@@ -66,7 +58,13 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
             return response.status;
         }
     }
-
+    
+    private formatUsers(users: { name: string; id: string }[]): string {
+        return users
+            .map(user => `${user.name},${user.id}`)
+            .join("\n");
+    }
+    
     private async push(
         invalidConfigNumber: string,
         invalidFileReferenceListUsers: string,

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
@@ -10,6 +10,11 @@ import { UserMonitoringFileResourceUtils } from "../common/UserMonitoringFileRes
 
 const dataelement_invalid_two_factor_count_code = "ADMIN_users_without_two_factor_count_7_Events";
 const dataelement_invalid_two_factor_usernames_list_code = "ADMIN_users_without_two_factor_8_Events";
+const dataelement_invalid_who_accounts_list = "ADMIN_users_with_invalid_who_account_9_Events";
+const dataelement_invalid_who_accounts = "ADMIN_users_with_invalid_who_account_count_10";
+const dataelement_invalid_auth_list = "ADMIN_users_without_auth_groups_11_Events";
+const dataelement_invalid_auth = "ADMIN_users_without_auth_groups_count_12_Events";
+
 const filenameUserReported = `_users_reported.csv`;
 type ServerResponse = { status: string; typeReports: object[] };
 
@@ -17,17 +22,40 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
     constructor(private api: D2Api) {}
     async save(program: UserMonitoringProgramMetadata, report: TwoFactorUserReport): Async<string> {
         const twoFactorUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
-            report.listOfAffectedUsers
+            report.invalidTwoFAList
                 .map(user => {
                     return user.name + "," + user.id;
                 })
                 .join("\n"),
-            filenameUserReported,
+            "_twoFa"+filenameUserReported,
+            this.api
+        );
+
+        const whoAccountUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
+            report.invalidWhoList
+                .map(user => {
+                    return user.name + "," + user.id;
+                })
+                .join("\n"),
+            "_who"+filenameUserReported,
+            this.api
+        );
+        const invalidUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
+            report.invalidAuthList
+                .map(user => {
+                    return user.name + "," + user.id;
+                })
+                .join("\n"),
+            "_invalid"+filenameUserReported,
             this.api
         );
         const response = await this.push(
-            report.invalidUsersCount.toString(),
+            report.invalidTwoFACount.toString(),
             twoFactorUsersFileResourceId,
+            report.invalidWhoCount.toString(),
+            whoAccountUsersFileResourceId,
+            report.invalidAuthCount.toString(),
+            invalidUsersFileResourceId,
             this.api,
             program
         );
@@ -41,7 +69,11 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
 
     private async push(
         invalidConfigNumber: string,
-        invalidConfigUsers: string,
+        invalidFileReferenceListUsers: string,
+        invalidWhoAccounts: string,
+        invalidFileReferenceWhoAccounts: string,
+        invalidAuth: string,
+        invalidFileReferenceAuth: string,
         api: D2Api,
         program: UserMonitoringProgramMetadata
     ) {
@@ -54,7 +86,19 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
                         return { dataElement: item.id, value: invalidConfigNumber };
                     case dataelement_invalid_two_factor_usernames_list_code:
                         if (invalidConfigNumber == "0") return { dataElement: "", value: "" };
-                        return { dataElement: item.id, value: invalidConfigUsers };
+                        return { dataElement: item.id, value: invalidFileReferenceListUsers };
+                    case dataelement_invalid_who_accounts:
+                        if (invalidWhoAccounts == "0") return { dataElement: "", value: "" };
+                        return { dataElement: item.id, value: invalidWhoAccounts };
+                    case dataelement_invalid_who_accounts_list:
+                        if (invalidFileReferenceWhoAccounts == "0") return { dataElement: "", value: "" };
+                        return { dataElement: item.id, value: invalidFileReferenceWhoAccounts };
+                    case dataelement_invalid_auth:
+                        if (invalidAuth == "0") return { dataElement: "", value: "" };
+                        return { dataElement: item.id, value: invalidAuth };
+                    case dataelement_invalid_auth_list:
+                        if (invalidFileReferenceAuth == "0") return { dataElement: "", value: "" };
+                        return { dataElement: item.id, value: invalidFileReferenceAuth };
                     default:
                         return { dataElement: "", value: "" };
                 }

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
@@ -24,29 +24,29 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
         const invalidTwoFAList = this.formatUsers(report.invalidTwoFAList);
         const invalidWhoList = this.formatUsers(report.invalidWhoList);
         const invalidAuthList = this.formatUsers(report.invalidAuthList);
-        
+
         const twoFactorUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
             invalidTwoFAList,
-            "_twoFa"+filenameUserReported,
+            "_twoFa" + filenameUserReported,
             this.api
         );
 
         const whoAccountUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
             invalidWhoList,
-            "_who"+filenameUserReported,
+            "_who" + filenameUserReported,
             this.api
         );
         const invalidUsersFileResourceId = await UserMonitoringFileResourceUtils.saveFileResource(
             invalidAuthList,
-            "_invalid"+filenameUserReported,
+            "_invalid" + filenameUserReported,
             this.api
         );
         const response = await this.push(
-            report.invalidTwoFACount.toString(),
+            report.invalidTwoFAList.length.toString(),
             twoFactorUsersFileResourceId,
-            report.invalidWhoCount.toString(),
+            report.invalidWhoList.length.toString(),
             whoAccountUsersFileResourceId,
-            report.invalidAuthCount.toString(),
+            report.invalidAuthList.length.toString(),
             invalidUsersFileResourceId,
             this.api,
             program
@@ -58,13 +58,11 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
             return response.status;
         }
     }
-    
+
     private formatUsers(users: { name: string; id: string }[]): string {
-        return users
-            .map(user => `${user.name},${user.id}`)
-            .join("\n");
+        return users.map(user => `${user.name},${user.id}`).join("\n");
     }
-    
+
     private async push(
         invalidConfigNumber: string,
         invalidFileReferenceListUsers: string,
@@ -77,30 +75,31 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
     ) {
         log.info(`Create and Pushing users without two factor report to DHIS2`);
 
-        const dataValues: UserMonitoringReportValues[] = program.dataElements
-            .map(item => {
+        const dataValues: UserMonitoringReportValues[] = _.compact(
+            program.dataElements.map((item): UserMonitoringReportValues | undefined => {
                 switch (item.code) {
                     case dataelement_invalid_two_factor_count_code:
                         return { dataElement: item.id, value: invalidConfigNumber };
                     case dataelement_invalid_two_factor_usernames_list_code:
-                        if (invalidConfigNumber == "0") return { dataElement: "", value: "" };
+                        if (invalidConfigNumber == "0") return undefined;
                         return { dataElement: item.id, value: invalidFileReferenceListUsers };
                     case dataelement_invalid_who_accounts:
-                        if (invalidWhoAccounts == "0") return { dataElement: "", value: "" };
+                        if (invalidWhoAccounts == "0") return undefined;
                         return { dataElement: item.id, value: invalidWhoAccounts };
                     case dataelement_invalid_who_accounts_list:
-                        if (invalidFileReferenceWhoAccounts == "0") return { dataElement: "", value: "" };
+                        if (invalidFileReferenceWhoAccounts == "0") return undefined;
                         return { dataElement: item.id, value: invalidFileReferenceWhoAccounts };
                     case dataelement_invalid_auth:
-                        if (invalidAuth == "0") return { dataElement: "", value: "" };
+                        if (invalidAuth == "0") return undefined;
                         return { dataElement: item.id, value: invalidAuth };
                     case dataelement_invalid_auth_list:
-                        if (invalidFileReferenceAuth == "0") return { dataElement: "", value: "" };
+                        if (invalidFileReferenceAuth == "0") return undefined;
                         return { dataElement: item.id, value: invalidFileReferenceAuth };
                     default:
-                        return { dataElement: "", value: "" };
+                        return undefined;
                 }
             })
+        )
             .filter(dataValue => dataValue.dataElement !== "")
             .filter(dataValue => dataValue.value !== "");
 

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository.ts
@@ -10,7 +10,6 @@ import { UserMonitoringFileResourceUtils } from "../common/UserMonitoringFileRes
 
 const dataelement_invalid_two_factor_count_code = "ADMIN_users_without_two_factor_count_7_Events";
 const dataelement_invalid_two_factor_usernames_list_code = "ADMIN_users_without_two_factor_8_Events";
-
 const filenameUserReported = `_users_reported.csv`;
 type ServerResponse = { status: string; typeReports: object[] };
 
@@ -54,10 +53,8 @@ export class TwoFactorReportD2Repository implements TwoFactorReportRepository {
                     case dataelement_invalid_two_factor_count_code:
                         return { dataElement: item.id, value: invalidConfigNumber };
                     case dataelement_invalid_two_factor_usernames_list_code:
-                        return {
-                            dataElement: item.id,
-                            value: invalidConfigUsers,
-                        };
+                        if (invalidConfigNumber == "0") return { dataElement: "", value: "" };
+                        return { dataElement: item.id, value: invalidConfigUsers };
                     default:
                         return { dataElement: "", value: "" };
                 }

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -11,6 +11,7 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     async getUsersByGroupId(groupIds: string[]): Async<TwoFactorUser[]> {
         log.info(`Get users by group: Users by ids: ${groupIds.join(",")}`);
         //todo use d2api filters
+
         const responses = await this.api
             .get<Users>(
                 `/users.json?paging=false&fields=*,userCredentials[*]&filter=userGroups.id:in:[${groupIds.join(
@@ -24,8 +25,37 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
                 id: user.id,
                 username: user.username,
                 twoFA: twoFA ?? false,
+                disabled: user.disabled ?? false,
+                externalAuth: user.externalAuth ?? false,
+                userGroups: user.userGroups ?? [],
             };
         });
     }
+
+    async disableUsers(userIds: string[]):Async<string>{
+        log.info(`Disabling users by ids: ${userIds.join(",")}`);
+
+        const results = await Promise.all(
+            userIds.map(async userId => {
+                try {
+                    const response = await this.api
+                        .request<string>({
+                            method: "patch",
+                            url: `/41/users/${userId}`,
+                            headers: { "Content-Type": "application/json-patch+json" },
+                            data: [{ op: "replace", path: "/disabled", value: true }],
+                        })
+                        .getData();
+
+                    return { userId, status: "success", response };
+                } catch (error) {
+                    log.error(`Error disabling user ${userId}:` + error);
+                    return { userId, status: "error", error };
+                }
+            })
+        );
+        return JSON.stringify(results);
+    }
 }
+
 type Users = { users: PermissionFixerUser[] };

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -16,13 +16,14 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
         //We need to check if the program metadata is valid due !in filter is not working propertly in dhis2 2.41
         const responses = await this.api
             .get<Users>(
-                `/users.json?paging=false&fields=id,username,disabled,externalAuth,userGroups,created,userCredentials[twoFa,twoFactorEnabled]&filter=userGroups.id:!in:[${excludeUserGroupIds.join(
+                `/users.json?paging=false&fields=id,username,disabled,externalAuth,userGroups,created,twoFa,twoFactorEnabled&filter=userGroups.id:!in:[${excludeUserGroupIds.join(
                     ","
                 )}]`
             )
             .getData();
+
         return responses["users"].map(user => {
-            const twoFA = user.userCredentials.twoFA || user.userCredentials.twoFactorEnabled;
+            const twoFA = user.twoFA || user.twoFactorEnabled;
             return {
                 id: user.id,
                 username: user.username,

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -5,11 +5,12 @@ import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monito
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
 import { PermissionFixerUser } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUser";
 import { Async } from "domain/entities/Async";
+import { Method } from "@eyeseetea/d2-api/repositories/HttpClientRepository";
 
 export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     constructor(private api: D2Api) {}
 
-    async getUsersNotInGroupIds(excludeUserGroupIds:string[]): Async<TwoFactorUser[]> {
+    async getUsersNotInGroupIds(excludeUserGroupIds: string[]): Async<TwoFactorUser[]> {
         log.info(`Get users not in group: ${excludeUserGroupIds.join(",")}`);
         //todo use d2api filters
         //We need to check if the program metadata is valid due !in filter is not working propertly in dhis2 2.41
@@ -33,7 +34,7 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
         });
     }
 
-    async disableUsers(userIds: string[]):Async<string>{
+    async disableUsers(userIds: string[]): Async<string> {
         log.info(`Disabling users by ids: ${userIds.join(",")}`);
 
         const results = await Promise.all(
@@ -41,7 +42,8 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
                 try {
                     const response = await this.api
                         .request<string>({
-                            method: "patch",
+                            // TEMPORAL. See https://github.com/EyeSeeTea/d2-api/pull/171
+                            method: "patch" as Method,
                             url: `/41/users/${userId}`,
                             headers: { "Content-Type": "application/json-patch+json" },
                             data: [{ op: "replace", path: "/disabled", value: true }],

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -12,7 +12,7 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     async getUsersNotInGroupIds(excludeUserGroupIds:string[]): Async<TwoFactorUser[]> {
         log.info(`Get users not in group: ${excludeUserGroupIds.join(",")}`);
         //todo use d2api filters
-
+        //We need to check if the program metadata is valid due !in filter is not working propertly in dhis2 2.41
         const responses = await this.api
             .get<Users>(
                 `/users.json?paging=false&fields=id,username,disabled,externalAuth,userGroups,created,userCredentials[twoFa,twoFactorEnabled]&filter=userGroups.id:!in:[${excludeUserGroupIds.join(

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -8,13 +8,14 @@ import { Async } from "domain/entities/Async";
 
 export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     constructor(private api: D2Api) {}
-    async getUsersByGroupId(groupIds: string[]): Async<TwoFactorUser[]> {
-        log.info(`Get users by group: Users by ids: ${groupIds.join(",")}`);
+
+    async getUsersNotInGroupIds(excludeUserGroupIds:string[]): Async<TwoFactorUser[]> {
+        log.info(`Get users not in group: ${excludeUserGroupIds.join(",")}`);
         //todo use d2api filters
 
         const responses = await this.api
             .get<Users>(
-                `/users.json?paging=false&fields=*,userCredentials[*]&filter=userGroups.id:in:[${groupIds.join(
+                `/users.json?paging=false&fields=id,username,disabled,externalAuth,userGroups,created,userCredentials[twoFa,twoFactorEnabled]&filter=userGroups.id:!in:[${excludeUserGroupIds.join(
                     ","
                 )}]`
             )

--- a/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerUser.ts
+++ b/src/domain/entities/user-monitoring/permission-fixer/PermissionFixerUser.ts
@@ -1,10 +1,12 @@
 import { Id, NamedRef, StringDateTime } from "domain/entities/Base";
+import { Maybe } from "utils/ts-utils";
 
 export interface PermissionFixerUser {
     id: Id;
     lastUpdatedBy: PermissionFixerUserDetails;
     createdBy: PermissionFixerUserDetails;
-    twoFA: boolean;
+    twoFA: Maybe<boolean>;
+    twoFactorEnabled: Maybe<boolean>;
     invitation: false;
     selftRefistered: false;
     firstName: string;

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
@@ -1,4 +1,3 @@
-import { Named } from "cmd-ts/dist/cjs/helpdoc";
 import { Id, NamedRef } from "domain/entities/Base";
 
 export interface TwoFactorUser {

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
@@ -1,7 +1,11 @@
-import { Id } from "domain/entities/Base";
+import { Named } from "cmd-ts/dist/cjs/helpdoc";
+import { Id, NamedRef } from "domain/entities/Base";
 
 export interface TwoFactorUser {
     id: Id;
     twoFA: boolean;
     username: string;
+    disabled: boolean;
+    externalAuth: boolean;
+    userGroups: NamedRef[];
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
@@ -4,7 +4,6 @@ export interface TwoFactorUserOptions {
     pushProgram: NamedRef;
     twoFactorGroup: NamedRef;
     config: {
-    disableInvalid: boolean,
     exceptionGroup?: NamedRef[]
     };
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
@@ -3,4 +3,8 @@ import { NamedRef } from "domain/entities/Base";
 export interface TwoFactorUserOptions {
     pushProgram: NamedRef;
     twoFactorGroup: NamedRef;
+    config: {
+    disableInvalid: boolean,
+    exceptionGroup?: NamedRef[]
+    };
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
@@ -3,7 +3,6 @@ import { NamedRef } from "domain/entities/Base";
 export interface TwoFactorUserOptions {
     pushProgram: NamedRef;
     twoFactorGroup: NamedRef;
-    config: {
+    whoAccountGroup?: NamedRef;
     exceptionGroup?: NamedRef[]
-    };
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
@@ -1,8 +1,9 @@
 import { NamedRef } from "domain/entities/Base";
+import { Maybe } from "utils/ts-utils";
 
 export interface TwoFactorUserOptions {
     pushProgram: NamedRef;
     twoFactorGroup: NamedRef;
-    whoAccountGroup?: NamedRef;
-    exceptionGroup?: NamedRef[]
+    whoAccountGroup: Maybe<NamedRef>;
+    exceptionGroup: Maybe<NamedRef[]>;
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport.ts
@@ -1,6 +1,10 @@
 import { NamedRef } from "domain/entities/Base";
 
 export type TwoFactorUserReport = {
-    invalidUsersCount: number;
-    listOfAffectedUsers: NamedRef[];
+    invalidTwoFACount: number;
+    invalidTwoFAList: NamedRef[];
+    invalidWhoCount: number;
+    invalidWhoList: NamedRef[];
+    invalidAuthCount: number;
+    invalidAuthList: NamedRef[];
 };

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport.ts
@@ -1,10 +1,7 @@
 import { NamedRef } from "domain/entities/Base";
 
 export type TwoFactorUserReport = {
-    invalidTwoFACount: number;
     invalidTwoFAList: NamedRef[];
-    invalidWhoCount: number;
     invalidWhoList: NamedRef[];
-    invalidAuthCount: number;
     invalidAuthList: NamedRef[];
 };

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException.ts
@@ -1,6 +1,0 @@
-export class NonUsersException extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = "NonUsersException";
-    }
-}

--- a/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
+++ b/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
@@ -2,5 +2,5 @@ import { Async } from "domain/entities/Async";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 
 export interface TwoFactorUserRepository {
-    getUsersByGroupId(groupIds: string[]): Async<TwoFactorUser[]>;
+    getUsersNotInGroupIds(excludeUserGroupIds:string[]): Async<TwoFactorUser[]>;
 }

--- a/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
+++ b/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
@@ -2,5 +2,5 @@ import { Async } from "domain/entities/Async";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 
 export interface TwoFactorUserRepository {
-    getUsersNotInGroupIds(excludeUserGroupIds:string[]): Async<TwoFactorUser[]>;
+    getUsersNotInGroupIds(excludeUserGroupIds: string[]): Async<TwoFactorUser[]>;
 }

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
@@ -40,6 +40,7 @@ export const programMetadata: UserMonitoringProgramMetadata = {
 export const fakeValidUser: PermissionFixerUser = {
     id: "CHbcHcmgoZ5",
     twoFA: false,
+    twoFactorEnabled: false,
     invitation: false,
     firstName: "Fake",
     name: "Fake Dummy",
@@ -101,6 +102,7 @@ export const fakeValidUser: PermissionFixerUser = {
 export const fakeInvalidUser: PermissionFixerUser = {
     id: "CHbcHcmgoZ5",
     twoFA: false,
+    twoFactorEnabled: false,
     invitation: false,
     firstName: "Fake",
     name: "Fake Dummy",
@@ -170,6 +172,7 @@ export const fakeInvalidUser: PermissionFixerUser = {
 export const fakeUserWithoutUserGroup: PermissionFixerUser = {
     id: "CHbcHcmgoZ5",
     twoFA: false,
+    twoFactorEnabled: false,
     invitation: false,
     firstName: "Fake",
     name: "Fake Dummy",

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -6,10 +6,11 @@ import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-mon
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
 import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
-import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
-import { log } from "console";
+import log from "utils/log";
 
-type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport, disableUsersMessage: string };
+
+
+type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 
 export class RunTwoFactorReportUseCase {
     constructor(
@@ -19,7 +20,7 @@ export class RunTwoFactorReportUseCase {
         private programRepository: UserMonitoringProgramD2Repository
     ) {}
 
-    async execute(): Async<TwoFactorReportResponse> {
+    async execute(shouldDisableInvalidUsers: boolean): Async<TwoFactorReportResponse> {
         const options = await this.configRepository.get();
 
         const twoFactorGroupUsers = await this.userRepository.getUsersByGroupId([options.twoFactorGroup.id]);
@@ -32,9 +33,7 @@ export class RunTwoFactorReportUseCase {
 
         const excludedUserGroups = options.config.exceptionGroup?.map(group => group.id) ?? [];
         const excludedUsers = twoFactorGroupUsers.filter(user => {
-            return (
-                user.userGroups.some(group => excludedUserGroups.includes(group.id))
-            );
+            return user.userGroups.some(group => excludedUserGroups.includes(group.id));
         });
 
         const activeUsersWithoutTwoFactor = twoFactorGroupUsers.filter(user => {
@@ -47,32 +46,39 @@ export class RunTwoFactorReportUseCase {
             "id"
         );
 
-        (options.config.exceptionGroup ?? []).map(group => group.id)
+        (options.config.exceptionGroup ?? []).map(group => group.id);
         const userItems = activeUsersWithoutTwoFactorFiltered.map(user => {
             return { id: user.id, name: user.username };
         });
 
         const report: TwoFactorUserReport = {
             invalidUsersCount: userItems.length,
-            listOfAffectedUsers: userItems ?? ["No users found"]
+            listOfAffectedUsers: userItems ?? ["No users found"],
         };
 
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
-        
+
         const saveResponse = await this.reportRepository.save(programMetadata, report);
-
-        const disabledUserResponse = await disableUsers(options.config.disableInvalid, activeUsersWithoutTwoFactorFiltered, this.userRepository);
-        return { message: saveResponse, disableUsersMessage: disabledUserResponse, report };
-    }
-}
-
-async function disableUsers(disableInvalid: boolean, activeUsersWithoutTwoFactorFiltered: TwoFactorUser[], userRepository: TwoFactorUserD2Repository): Async<string> {
-    if (disableInvalid) {
-            const disableResponse = await userRepository.disableUsers(
+        log.info(`Report saved with status: ${activeUsersWithoutTwoFactorFiltered.length}`);
+        if (shouldDisableInvalidUsers && activeUsersWithoutTwoFactorFiltered.length > 0) {
+            const disableResponse = await this.userRepository.disableUsers(
                 activeUsersWithoutTwoFactorFiltered.map(user => user.id)
             );
-            return JSON.stringify(disableResponse);;
+            return { message: saveResponse, disableUsersMessage: JSON.stringify(disableResponse), report };
+        } else {
+            if (shouldDisableInvalidUsers) {
+                return {
+                    message: saveResponse,
+                    disableUsersMessage: "Disabled users action is not executed due not invalid users found.",
+                    report,
+                };
+            } else {
+                return {
+                    message: saveResponse,
+                    disableUsersMessage: "Disabled users action is not enabled.",
+                    report,
+                };
+            }
+        }
     }
-    return "Disabled users action is not enabled."
 }
-

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -8,8 +8,6 @@ import { Async } from "domain/entities/Async";
 import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
 import log from "utils/log";
 
-
-
 type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 
 export class RunTwoFactorReportUseCase {
@@ -22,62 +20,92 @@ export class RunTwoFactorReportUseCase {
 
     async execute(shouldDisableInvalidUsers: boolean): Async<TwoFactorReportResponse> {
         const options = await this.configRepository.get();
+        const programMetadata = await this.programRepository.get(options.pushProgram.id);
 
-        const twoFactorGroupUsers = await this.userRepository.getUsersByGroupId([options.twoFactorGroup.id]);
+        const excludedUserGroups = options.exceptionGroup?.map(group => group.id) ?? [];
+        const allUsersExceptExcluded = await this.userRepository.getUsersNotInGroupIds(excludedUserGroups);
 
-        if (!twoFactorGroupUsers) {
-            throw new NonUsersException(
-                "Users not found in the group. Check the group id. " + options.twoFactorGroup.id
-            );
+        if (!allUsersExceptExcluded) {
+            const report: TwoFactorUserReport = {
+                invalidTwoFACount: 0,
+                invalidTwoFAList: [],
+                invalidWhoCount: 0,
+                invalidWhoList: [],
+                invalidAuthCount: 0,
+                invalidAuthList: [],
+            };
+            const saveResponse = await this.reportRepository.save(programMetadata, report);
+            return {
+                message: saveResponse,
+                disableUsersMessage: "No users found.",
+                report,
+            };
         }
 
-        const excludedUserGroups = options.config.exceptionGroup?.map(group => group.id) ?? [];
-        const excludedUsers = twoFactorGroupUsers.filter(user => {
-            return user.userGroups.some(group => excludedUserGroups.includes(group.id));
+        const twoFactorUsers = allUsersExceptExcluded.filter(user => {
+            return user.userGroups.some(group => options.twoFactorGroup.id === group.id);
         });
 
-        const activeUsersWithoutTwoFactor = twoFactorGroupUsers.filter(user => {
-            return user.twoFA == false && user.disabled == false && user.externalAuth == false;
+        const invalidTwoFactorUsers = twoFactorUsers.filter(user => {
+            return user.twoFA == false && user.disabled == false;
         });
 
-        const activeUsersWithoutTwoFactorFiltered = _.differenceBy(
-            activeUsersWithoutTwoFactor,
-            excludedUsers,
-            "id"
-        );
+        const whoAccountUsers = allUsersExceptExcluded.filter(user => {
+            return user.userGroups.some(group => options.whoAccountGroup?.id === group.id);
+        });
 
-        (options.config.exceptionGroup ?? []).map(group => group.id);
-        const userItems = activeUsersWithoutTwoFactorFiltered.map(user => {
-            return { id: user.id, name: user.username };
+        const whoInvalidUsers = whoAccountUsers.filter(user => {
+            return user.disabled == false && user.externalAuth == false;
+        });
+
+        const allInvalidUsers = allUsersExceptExcluded.filter(user => {
+            const isInvalid = user.twoFA == false && user.disabled == false && user.externalAuth == false;
+
+            const isInInvalidTwoFA = invalidTwoFactorUsers.some(u => u.id === user.id);
+            const isInWhoInvalid = whoInvalidUsers.some(u => u.id === user.id);
+
+            return isInvalid && !isInInvalidTwoFA && !isInWhoInvalid;
         });
 
         const report: TwoFactorUserReport = {
-            invalidUsersCount: userItems.length,
-            listOfAffectedUsers: userItems ?? ["No users found"],
+            invalidTwoFACount: invalidTwoFactorUsers.length,
+            invalidTwoFAList: invalidTwoFactorUsers.map(user => {
+                return { id: user.id, name: user.username };
+            }) ?? ["No users found"],
+            invalidWhoCount: whoInvalidUsers.length,
+            invalidWhoList: whoInvalidUsers.map(user => {
+                return { id: user.id, name: user.username };
+            }) ?? ["No users found"],
+            invalidAuthCount: allInvalidUsers.length,
+            invalidAuthList: allInvalidUsers.map(user => {
+                return { id: user.id, name: user.username };
+            }) ?? ["No users found"],
         };
 
-        const programMetadata = await this.programRepository.get(options.pushProgram.id);
-
         const saveResponse = await this.reportRepository.save(programMetadata, report);
-        if (shouldDisableInvalidUsers && activeUsersWithoutTwoFactorFiltered.length > 0) {
-            const disableResponse = await this.userRepository.disableUsers(
-                activeUsersWithoutTwoFactorFiltered.map(user => user.id)
-            );
-            return { message: saveResponse, disableUsersMessage: JSON.stringify(disableResponse), report };
-        } else {
-            if (shouldDisableInvalidUsers) {
+        if (shouldDisableInvalidUsers) {
+            if (invalidTwoFactorUsers.length > 0) {
+                const disableResponse = await this.userRepository.disableUsers(
+                    invalidTwoFactorUsers.map(user => user.id)
+                );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: "Disabled users action is not executed due not invalid users found.",
+                    disableUsersMessage: JSON.stringify(disableResponse),
                     report,
                 };
             } else {
                 return {
                     message: saveResponse,
-                    disableUsersMessage: "Disabled users action is not enabled.",
+                    disableUsersMessage:
+                        "Disabled users action is not executed due to no invalid users found.",
                     report,
                 };
             }
         }
+        return {
+            message: saveResponse,
+            disableUsersMessage: "Disabled users action is not enabled.",
+            report,
+        };
     }
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -21,7 +21,7 @@ export class RunTwoFactorReportUseCase {
     async execute(shouldDisableInvalidUsers: boolean): Async<TwoFactorReportResponse> {
         const options = await this.configRepository.get();
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
-
+        
         const excludedUserGroups = options.exceptionGroup?.map(group => group.id) ?? [];
         const allUsers = await this.userRepository.getUsersNotInGroupIds(excludedUserGroups);
 
@@ -41,6 +41,8 @@ export class RunTwoFactorReportUseCase {
                 report,
             };
         }
+
+        //We need to check if the program metadata is valid due !in filter is not working propertly in dhis2 2.41
         const allUsersExceptExcluded = allUsers.filter(user => {
             return !user.userGroups.some(group => excludedUserGroups.includes(group.id));
         });

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -16,7 +16,8 @@ export class RunTwoFactorReportUseCase {
         private programRepository: UserMonitoringProgramD2Repository
     ) {}
 
-    async execute(shouldDisableInvalidUsers: boolean): Async<TwoFactorReportResponse> {
+    async execute(twoFactorUseCaseOption: TwoFactorUseCaseOptions): Async<TwoFactorReportResponse> {
+        const shouldDisableInvalidUsers = twoFactorUseCaseOption.shouldDisableInvalidUsers;
         const options = await this.configRepository.get();
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
         
@@ -113,4 +114,8 @@ export class RunTwoFactorReportUseCase {
             report,
         };
     }
+}
+
+interface TwoFactorUseCaseOptions {
+  shouldDisableInvalidUsers: boolean;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -5,8 +5,6 @@ import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/U
 import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
-import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
-import log from "utils/log";
 
 type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -59,7 +59,6 @@ export class RunTwoFactorReportUseCase {
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
 
         const saveResponse = await this.reportRepository.save(programMetadata, report);
-        log.info(`Report saved with status: ${activeUsersWithoutTwoFactorFiltered.length}`);
         if (shouldDisableInvalidUsers && activeUsersWithoutTwoFactorFiltered.length > 0) {
             const disableResponse = await this.userRepository.disableUsers(
                 activeUsersWithoutTwoFactorFiltered.map(user => user.id)

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -6,8 +6,10 @@ import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-mon
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
 import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
+import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
+import { log } from "console";
 
-type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport };
+type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport, disableUsersMessage: string };
 
 export class RunTwoFactorReportUseCase {
     constructor(
@@ -19,6 +21,7 @@ export class RunTwoFactorReportUseCase {
 
     async execute(): Async<TwoFactorReportResponse> {
         const options = await this.configRepository.get();
+
         const twoFactorGroupUsers = await this.userRepository.getUsersByGroupId([options.twoFactorGroup.id]);
 
         if (!twoFactorGroupUsers) {
@@ -27,18 +30,49 @@ export class RunTwoFactorReportUseCase {
             );
         }
 
-        const usersWithoutTwoFactor = twoFactorGroupUsers.filter(user => {
-            return user.twoFA == false;
+        const excludedUserGroups = options.config.exceptionGroup?.map(group => group.id) ?? [];
+        const excludedUsers = twoFactorGroupUsers.filter(user => {
+            return (
+                user.userGroups.some(group => excludedUserGroups.includes(group.id))
+            );
         });
-        const userItems = usersWithoutTwoFactor.map(user => {
+
+        const activeUsersWithoutTwoFactor = twoFactorGroupUsers.filter(user => {
+            return user.twoFA == false && user.disabled == false && user.externalAuth == false;
+        });
+
+        const activeUsersWithoutTwoFactorFiltered = _.differenceBy(
+            activeUsersWithoutTwoFactor,
+            excludedUsers,
+            "id"
+        );
+
+        (options.config.exceptionGroup ?? []).map(group => group.id)
+        const userItems = activeUsersWithoutTwoFactorFiltered.map(user => {
             return { id: user.id, name: user.username };
         });
+
         const report: TwoFactorUserReport = {
             invalidUsersCount: userItems.length,
-            listOfAffectedUsers: userItems,
+            listOfAffectedUsers: userItems ?? ["No users found"]
         };
+
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
+        
         const saveResponse = await this.reportRepository.save(programMetadata, report);
-        return { message: saveResponse, report };
+
+        const disabledUserResponse = await disableUsers(options.config.disableInvalid, activeUsersWithoutTwoFactorFiltered, this.userRepository);
+        return { message: saveResponse, disableUsersMessage: disabledUserResponse, report };
     }
 }
+
+async function disableUsers(disableInvalid: boolean, activeUsersWithoutTwoFactorFiltered: TwoFactorUser[], userRepository: TwoFactorUserD2Repository): Async<string> {
+    if (disableInvalid) {
+            const disableResponse = await userRepository.disableUsers(
+                activeUsersWithoutTwoFactorFiltered.map(user => user.id)
+            );
+            return JSON.stringify(disableResponse);;
+    }
+    return "Disabled users action is not enabled."
+}
+

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -20,7 +20,7 @@ export class RunTwoFactorReportUseCase {
         const shouldDisableInvalidUsers = twoFactorUseCaseOption.shouldDisableInvalidUsers;
         const options = await this.configRepository.get();
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
-        
+
         const excludedUserGroups = options.exceptionGroup?.map(group => group.id) ?? [];
         const allUsers = await this.userRepository.getUsersNotInGroupIds(excludedUserGroups);
 
@@ -79,13 +79,13 @@ export class RunTwoFactorReportUseCase {
         const report: TwoFactorUserReport = {
             invalidTwoFAList: invalidTwoFactorUsers.map(user => {
                 return { id: user.id, name: user.username };
-            }) ?? ["No users found"],
+            }),
             invalidWhoList: whoInvalidUsers.map(user => {
                 return { id: user.id, name: user.username };
-            }) ?? ["No users found"],
+            }),
             invalidAuthList: allInvalidUsers.map(user => {
                 return { id: user.id, name: user.username };
-            }) ?? ["No users found"],
+            }),
         };
 
         const saveResponse = await this.reportRepository.save(programMetadata, report);
@@ -117,5 +117,5 @@ export class RunTwoFactorReportUseCase {
 }
 
 interface TwoFactorUseCaseOptions {
-  shouldDisableInvalidUsers: boolean;
+    shouldDisableInvalidUsers: boolean;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -25,11 +25,8 @@ export class RunTwoFactorReportUseCase {
 
         if (!allUsers) {
             const report: TwoFactorUserReport = {
-                invalidTwoFACount: 0,
                 invalidTwoFAList: [],
-                invalidWhoCount: 0,
                 invalidWhoList: [],
-                invalidAuthCount: 0,
                 invalidAuthList: [],
             };
             const saveResponse = await this.reportRepository.save(programMetadata, report);
@@ -79,15 +76,12 @@ export class RunTwoFactorReportUseCase {
         });
 
         const report: TwoFactorUserReport = {
-            invalidTwoFACount: invalidTwoFactorUsers.length,
             invalidTwoFAList: invalidTwoFactorUsers.map(user => {
                 return { id: user.id, name: user.username };
             }) ?? ["No users found"],
-            invalidWhoCount: whoInvalidUsers.length,
             invalidWhoList: whoInvalidUsers.map(user => {
                 return { id: user.id, name: user.username };
             }) ?? ["No users found"],
-            invalidAuthCount: allInvalidUsers.length,
             invalidAuthList: allInvalidUsers.map(user => {
                 return { id: user.id, name: user.username };
             }) ?? ["No users found"],

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -23,9 +23,9 @@ export class RunTwoFactorReportUseCase {
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
 
         const excludedUserGroups = options.exceptionGroup?.map(group => group.id) ?? [];
-        const allUsersExceptExcluded = await this.userRepository.getUsersNotInGroupIds(excludedUserGroups);
+        const allUsers = await this.userRepository.getUsersNotInGroupIds(excludedUserGroups);
 
-        if (!allUsersExceptExcluded) {
+        if (!allUsers) {
             const report: TwoFactorUserReport = {
                 invalidTwoFACount: 0,
                 invalidTwoFAList: [],
@@ -41,13 +41,16 @@ export class RunTwoFactorReportUseCase {
                 report,
             };
         }
+        const allUsersExceptExcluded = allUsers.filter(user => {
+            return !user.userGroups.some(group => excludedUserGroups.includes(group.id));
+        });
 
         const twoFactorUsers = allUsersExceptExcluded.filter(user => {
             return user.userGroups.some(group => options.twoFactorGroup.id === group.id);
         });
 
         const invalidTwoFactorUsers = twoFactorUsers.filter(user => {
-            return user.twoFA == false && user.disabled == false;
+            return user.externalAuth == false && user.twoFA == false && user.disabled == false;
         });
 
         const whoAccountUsers = allUsersExceptExcluded.filter(user => {
@@ -58,13 +61,21 @@ export class RunTwoFactorReportUseCase {
             return user.disabled == false && user.externalAuth == false;
         });
 
+        const usersNotInWhoOr2FA = allUsersExceptExcluded.filter(user => {
+            const isInWho = whoAccountUsers.includes(user);
+            const isIn2FA = twoFactorUsers.includes(user);
+            return !isInWho && !isIn2FA;
+        });
+
+        // Filter all active users with wrong configurations
         const allInvalidUsers = allUsersExceptExcluded.filter(user => {
-            const isInvalid = user.twoFA == false && user.disabled == false && user.externalAuth == false;
+            const isEnabled = user.disabled == false;
 
-            const isInInvalidTwoFA = invalidTwoFactorUsers.some(u => u.id === user.id);
-            const isInWhoInvalid = whoInvalidUsers.some(u => u.id === user.id);
+            const isInWhoGroup = whoAccountUsers.some(u => u.id === user.id);
+            const isInAuthGroup = twoFactorUsers.some(u => u.id === user.id);
+            const isNotInWhoOr2FA = usersNotInWhoOr2FA.some(u => u.id === user.id);
 
-            return isInvalid && !isInInvalidTwoFA && !isInWhoInvalid;
+            return isEnabled && ((isInWhoGroup && isInAuthGroup) || isNotInWhoOr2FA);
         });
 
         const report: TwoFactorUserReport = {

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -4,12 +4,11 @@ import { RunTwoFactorReportUseCase } from "../RunTwoFactorReportUseCase";
 import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
 import { anything, deepEqual, instance, mock, when } from "ts-mockito";
 import {
-    config_exception_and_disabled,
-    default_config,
-    listOfUsers,
+    listOfUsersOneValidOneInvalid,
     listOfUsersWithTwoInvalid,
     listOfUsersWithTwoValid,
     mixedInvalidUsers,
+    userInTwoFAGroupButWithExternalAuth,
     userInvalidAuth,
     userWithoutExternalAuth,
     userWithoutTwoFA,
@@ -20,12 +19,181 @@ import { TwoFactorUserD2Repository } from "data/user-monitoring/two-factor-monit
 import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
-import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
 import { TwoFactorUserOptions } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions";
+const TWO_FACTOR_GROUP_ID = "2FA";
+const WHO_ACCOUNT_GROUP_ID = "WHO";
+const EXCEPTION_GROUP_ID = "EXC";
+
+const baseUser = {
+    externalAuth: false,
+    disabled: false,
+    twoFA: false,
+    username: "testuser",
+};
+
+const defaultConfig: TwoFactorUserOptions = {
+    pushProgram: { id: "program", name: "Program" },
+    twoFactorGroup: { id: TWO_FACTOR_GROUP_ID, name: "2FA Group" },
+    whoAccountGroup: { id: WHO_ACCOUNT_GROUP_ID, name: "WHO Group" },
+    exceptionGroup: [{ id: EXCEPTION_GROUP_ID, name: "Exception Group" }],
+};
+const alternativeConfig: TwoFactorUserOptions = {
+    pushProgram: {
+        id: "IKpEgoQ4S0r",
+        name: "Event program uid",
+    },
+    twoFactorGroup: {
+        id: "MkELexlZOj9",
+        name: "TwoFactor usergroup",
+    },
+    whoAccountGroup: {
+        id: "MkELexlZOj8",
+        name: "Who account usergroup",
+    },
+    exceptionGroup: [
+    ]
+};
+
 
 describe("TwoFactorReportUseCase", () => {
-    it("Should push report with 0 affected users and empty affected user list if one user has two factor activated", async () => {
-        const useCase = givenUsers([userWithTwoFA]);
+    it("Should detects a user in 2FA group with twoFA disabled as invalidTwoFA", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u1",
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "u1", name: "testuser" }]);
+        expect(result.report.invalidWhoList).toEqual([]);
+        expect(result.report.invalidAuthList).toEqual([]);
+    });
+
+    it("Should detects 0 users in 2FA group with twoFA enabled", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u1",
+            twoFA: true,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([]);
+        expect(result.report.invalidAuthList).toEqual([]);
+    });
+
+    it("Should detects a user in WHO group with externalAuth false as invalidWho", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u2",
+            userGroups: [{ id: WHO_ACCOUNT_GROUP_ID, name: "" }],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([{ id: "u2", name: "testuser" }]);
+        expect(result.report.invalidAuthList).toEqual([]);
+    });
+
+    it("Should ignores user in exception group even if invalid", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u3",
+            userGroups: [{ id: EXCEPTION_GROUP_ID, name: "" }],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([]);
+        expect(result.report.invalidAuthList).toEqual([]);
+    });
+
+    it("Should detects user not in 2FA nor WHO as invalidAuth", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u4",
+            userGroups: [],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([]);
+        expect(result.report.invalidAuthList).toEqual([{ id: "u4", name: "testuser" }]);
+    });
+
+    it("Should detects invalid user in both 2FA and WHO as invalidWho and invalidTwoFa and invalidAuth", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u5",
+            userGroups: [
+                { id: TWO_FACTOR_GROUP_ID, name: "" },
+                { id: WHO_ACCOUNT_GROUP_ID, name: "" },
+            ],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "u5", name: "testuser" }]);
+        expect(result.report.invalidWhoList).toEqual([{ id: "u5", name: "testuser" }]);
+        expect(result.report.invalidAuthList).toEqual([{ id: "u5", name: "testuser" }]);
+    });
+
+    it("Should detects invalid user in WHO as invalidWho and invalidAuth", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u5",
+            twoFA: true,
+            userGroups: [
+                { id: TWO_FACTOR_GROUP_ID, name: "" },
+                { id: WHO_ACCOUNT_GROUP_ID, name: "" },
+            ],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([{ id: "u5", name: "testuser" }]);
+        expect(result.report.invalidAuthList).toEqual([{ id: "u5", name: "testuser" }]);
+    });
+
+    it("Should detects invalid user in twoFA but valid who only as invalidAuth", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u5",
+            externalAuth: true,
+            userGroups: [
+                { id: TWO_FACTOR_GROUP_ID, name: "" },
+                { id: WHO_ACCOUNT_GROUP_ID, name: "" },
+            ],
+        };
+        const useCase = createUseCase({ users: [user], config: defaultConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFAList).toEqual([]);
+        expect(result.report.invalidWhoList).toEqual([]);
+        expect(result.report.invalidAuthList).toEqual([{ id: "u5", name: "testuser" }]);
+    });
+
+    it("Should push report with 0 affected users and empty affected user list if all the users has two factor activated and one with two factor disabled but externalAccess true", async () => {
+        const useCase = createUseCase({
+            users: [userWithTwoFA, userWithTwoFA, userInTwoFAGroupButWithExternalAuth],
+        });
 
         const result = await useCase.execute(false);
 
@@ -34,40 +202,8 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.message).toEqual("OK");
     });
 
-    it("Should push report with 0 affected users and empty affected user list if all the users has two factor activated", async () => {
-        const useCase = givenUsers([userWithTwoFA, userWithTwoFA]);
-
-        const result = await useCase.execute(false);
-
-        expect(result.report.invalidTwoFACount).toEqual(0);
-        expect(result.report.invalidTwoFAList).toEqual([]);
-        expect(result.message).toEqual("OK");
-    });
-
-    it("Should push report with 0 affected users and empty affected user list if all the users has no two factor activated", async () => {
-        const useCase = givenUsers([userWithTwoFA, userWithTwoFA]);
-
-        const result = await useCase.execute(false);
-
-        expect(result.report.invalidTwoFACount).toEqual(0);
-        expect(result.report.invalidTwoFAList).toEqual([]);
-        expect(result.message).toEqual("OK");
-    });
-    
-    
-    it("Should push report with 1 affected users and 1 affected user list if 1 user has two factor deactivated", async () => {
-        const useCase = givenUsers([userWithoutTwoFA]);
-
-        const result = await useCase.execute(false);
-
-        const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
-        expect(result.report.invalidTwoFACount).toEqual(1);
-        expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
-        expect(result.message).toEqual("OK");
-    });
-    
     it("Should push report 1 affected user if we provide a list with two users, and only one has two-factor authentication disabled.", async () => {
-        const useCase = givenUsers(listOfUsers);
+        const useCase = createUseCase({ users: listOfUsersOneValidOneInvalid });
 
         const result = await useCase.execute(false);
 
@@ -76,9 +212,9 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
         expect(result.message).toEqual("OK");
     });
-    
+
     it("Should push report 2 affected users and a list of 2 affected user if 2 user has two factor deactivate and 1 activated", async () => {
-        const useCase = givenUsers(listOfUsersWithTwoInvalid);
+        const useCase = createUseCase({ users: listOfUsersWithTwoInvalid });
 
         const result = await useCase.execute(false);
 
@@ -90,9 +226,9 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
-    
+
     it("Should push report 1 affected users and a list of 1 affected user if 1 user has two factor deactivate and 2 activated", async () => {
-        const useCase = givenUsers(listOfUsersWithTwoValid);
+        const useCase = createUseCase({ users: listOfUsersWithTwoValid });
 
         const result = await useCase.execute(false);
 
@@ -102,169 +238,94 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.message).toEqual("OK");
     });
 
-    it("Should report 0 users if reported users was in exception usergroup", async () => {
-    const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], config_exception_and_disabled);
+    it("Should detects 0 users if only exist disabled users", async () => {
+        const disabledUser = { ...userWithoutTwoFA, disabled: true };
+        const useCase = createUseCase({ users: [userWithTwoFA, disabledUser], config: alternativeConfig });
 
-    const result = await useCase.execute(true);
+        const result = await useCase.execute(true);
 
-    expect(result.report.invalidTwoFACount).toEqual(0);
-    expect(result.report.invalidTwoFAList).toEqual([]);
-    expect(result.disableUsersMessage).contain("No users found.");
-    expect(result.message).toBe("OK");
-}); 
-    it("Should ignore disabled users if only exist disabled users", async () => {
-    const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithTwoFA, disabledUser], default_config);
+        expect(result.report.invalidTwoFACount).toEqual(0);
+        expect(result.report.invalidTwoFAList).toEqual([]);
+    });
 
-    const result = await useCase.execute(true);
+    it("Should execute disabled acction in enabled (invalid) users when 'disabledusers' is true", async () => {
+        const disabledUser = { ...userWithoutTwoFA, disabled: true };
+        const useCase = createUseCase({
+            users: [userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled],
+            config: alternativeConfig,
+        });
 
-    expect(result.report.invalidTwoFACount).toEqual(0);
-    expect(result.report.invalidTwoFAList).toEqual([]);
-}); 
+        const result = await useCase.execute(true);
 
-    it("Should report 1 user if two exist without twoFA but only 1 is enabled", async () => {
-    const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], default_config);
+        const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
+        expect(result.report.invalidTwoFACount).toEqual(1);
+        expect(result.report.invalidTwoFAList).toEqual(expectedReport);
+        expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
+    });
 
-    const result = await useCase.execute(true);
+    it("Should skip disabling users when 'disabledusers' is false, even if there are invalid users", async () => {
+        const disabledUser = { ...userWithoutTwoFA, disabled: true };
+        const useCase = createUseCase({
+            users: [userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled],
+            config: alternativeConfig,
+        });
 
-    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-    expect(result.report.invalidTwoFACount).toEqual(1);
-    expect(result.report.invalidTwoFAList).toEqual(expectedReport);
-    expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
+        const result = await useCase.execute(false);
+
+        const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
+        expect(result.report.invalidTwoFACount).toEqual(1);
+        expect(result.report.invalidTwoFAList).toEqual(expectedReport);
+        expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
+    });
+
+    it("Should classify users into correct invalid categories (2FA, WHO, AUTH)", async () => {
+        const useCase = createUseCase({ users: mixedInvalidUsers, config: alternativeConfig });
+
+        const result = await useCase.execute(false);
+
+        expect(result.report.invalidTwoFACount).toBe(1);
+        expect(result.report.invalidWhoCount).toBe(1);
+        expect(result.report.invalidAuthCount).toBe(1);
+
+        expect(result.report.invalidTwoFAList).toEqual([
+            { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
+        ]);
+        expect(result.report.invalidWhoList).toEqual([
+            { id: userWithoutExternalAuth.id, name: userWithoutExternalAuth.username },
+        ]);
+        expect(result.report.invalidAuthList).toEqual([
+            { id: userInvalidAuth.id, name: userInvalidAuth.username },
+        ]);
+    });
 });
 
-    it("Should report Disabled users action is not enabled. If disabledInvalid is false", async () => {
-    const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], default_config);
+function createUseCase({
+    users,
+    config = alternativeConfig,
+}: {
+    users: TwoFactorUser[];
+    config?: TwoFactorUserOptions;
+    programId?: string;
+    programName?: string;
+}): RunTwoFactorReportUseCase {
+    const excludedGroupIds = config.exceptionGroup?.map(g => g.id) ?? [];
 
-    const result = await useCase.execute(false);
+    const userRepo = mock(TwoFactorUserD2Repository);
+    when(userRepo.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenResolve(users);
+    when(userRepo.disableUsers(anything())).thenResolve("Disabled users action is enabled and executed.");
 
-    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-    expect(result.report.invalidTwoFACount).toEqual(1);
-    expect(result.report.invalidTwoFAList).toEqual(expectedReport);
-    expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
-}); 
+    const reportRepo = mock(TwoFactorReportD2Repository);
+    when(reportRepo.save(anything(), anything())).thenResolve("OK");
 
-    it("Should report Disabled users action is not executed due to no invalid users found. If disabledInvalid is true but all users are disabled", async () => {
-    const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([disabledUser, userWithoutTwoFAdisabled], default_config);
+    const configRepo = mock(TwoFactorConfigD2Repository);
+    when(configRepo.get()).thenResolve(config);
 
-    const result = await useCase.execute(true);
+    const programRepo = mock(UserMonitoringProgramD2Repository);
 
-    expect(result.report.invalidTwoFACount).toEqual(0); 
-    expect(result.disableUsersMessage).toContain("Disabled users action is not executed due to no invalid users found.");
-}); 
-
-it("Should not fail if whoAccountGroup is undefined", async () => {
-    const configWithoutWHO = { ...default_config, whoAccountGroup: undefined };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA], configWithoutWHO);
-
-    const result = await useCase.execute(false);
-
-    expect(result.report.invalidWhoCount).toBe(0);
-    expect(result.report.invalidWhoList).toEqual([]);
-});
-
-it("Should report WHO-invalid users correctly", async () => {
-    const useCase = givenUsersWithConfig([userWithoutExternalAuth], default_config);
-
-    const result = await useCase.execute(false);
-
-    expect(result.report.invalidWhoCount).toBe(1);
-    expect(result.report.invalidWhoList).toEqual([
-        { id: userWithoutExternalAuth.id, name: userWithoutExternalAuth.username }
-    ]);
-});
-
-it("Should report auth-invalid users correctly (not in 2FA or WHO)", async () => {
-    const useCase = givenUsersWithConfig([userInvalidAuth], default_config);
-
-    const result = await useCase.execute(false);
-
-    expect(result.report.invalidAuthCount).toBe(1);
-    expect(result.report.invalidAuthList).toEqual([
-        { id: userInvalidAuth.id, name: userInvalidAuth.username }
-    ]);
-});
-
-it("Should classify users into correct invalid categories (2FA, WHO, AUTH)", async () => {
-    const useCase = givenUsersWithConfig(mixedInvalidUsers, default_config);
-
-    const result = await useCase.execute(false);
-
-    expect(result.report.invalidTwoFACount).toBe(1);
-    expect(result.report.invalidWhoCount).toBe(1);
-    expect(result.report.invalidAuthCount).toBe(1);
-
-    expect(result.report.invalidTwoFAList).toEqual([
-        { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }
-    ]);
-    expect(result.report.invalidWhoList).toEqual([
-        { id: userWithoutExternalAuth.id, name: userWithoutExternalAuth.username }
-    ]);
-    expect(result.report.invalidAuthList).toEqual([
-        { id: userInvalidAuth.id, name: userInvalidAuth.username }
-    ]);
-});
-
-
-});
-
-function givenUsersWithConfig(users: TwoFactorUser[], config = default_config) {
-    const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository(users),
-        givenTwoFactorReportD2Repository(),
-        givenConfigRepository(config),
-        givenUserMonitoringProgramD2Repository()
+    return new RunTwoFactorReportUseCase(
+        instance(userRepo),
+        instance(reportRepo),
+        instance(configRepo),
+        instance(programRepo)
     );
-    return useCase;
-}
-
-
-function givenUsers(users: TwoFactorUser[]) {
-    const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository(users),
-        givenTwoFactorReportD2Repository(),
-        givenConfigRepository(),
-        givenUserMonitoringProgramD2Repository()
-    );
-    return useCase;
-}
-
-function givenInvalidUserGroupId() {
-    const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository([], ["invalidGroupId"]),
-        givenTwoFactorReportD2Repository(),
-        givenConfigRepository(),
-        givenUserMonitoringProgramD2Repository()
-    );
-    return useCase;
-}
-
-function givenUserRepository(users: TwoFactorUser[], excludedGroupIds =  default_config.exceptionGroup?.map(group => group.id) ?? []) {
-    const mockedRepository = mock(TwoFactorUserD2Repository);
-    when(mockedRepository.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenReturn(Promise.resolve(users));
-    when(mockedRepository.disableUsers(anything())).thenReturn(Promise.resolve("Disabled users action is enabled and executed."));
-    const configRepository = instance(mockedRepository);
-    return configRepository;
-}
-function givenTwoFactorReportD2Repository() {
-    const mockedRepository = mock(TwoFactorReportD2Repository);
-    when(mockedRepository.save(anything(), anything())).thenReturn(Promise.resolve("OK"));
-    const reportRepository = instance(mockedRepository);
-    return reportRepository;
-}
-function givenUserMonitoringProgramD2Repository() {
-    const mockedRepository = mock(UserMonitoringProgramD2Repository);
-    const reportRepository = instance(mockedRepository);
-    return reportRepository;
-}
-
-function givenConfigRepository(config: TwoFactorUserOptions = default_config) {
-    const mockedRepository = mock(TwoFactorConfigD2Repository);
-    when(mockedRepository.get()).thenReturn(Promise.resolve(config));
-    const configRepository = instance(mockedRepository);
-    return configRepository;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -9,6 +9,9 @@ import {
     listOfUsers,
     listOfUsersWithTwoInvalid,
     listOfUsersWithTwoValid,
+    mixedInvalidUsers,
+    userInvalidAuth,
+    userWithoutExternalAuth,
     userWithoutTwoFA,
     userWithoutTwoFAdisabled,
     userWithTwoFA,
@@ -26,8 +29,8 @@ describe("TwoFactorReportUseCase", () => {
 
         const result = await useCase.execute(false);
 
-        expect(result.report.invalidUsersCount).toEqual(0);
-        expect(result.report.listOfAffectedUsers).toEqual([]);
+        expect(result.report.invalidTwoFACount).toEqual(0);
+        expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.message).toEqual("OK");
     });
 
@@ -36,8 +39,8 @@ describe("TwoFactorReportUseCase", () => {
 
         const result = await useCase.execute(false);
 
-        expect(result.report.invalidUsersCount).toEqual(0);
-        expect(result.report.listOfAffectedUsers).toEqual([]);
+        expect(result.report.invalidTwoFACount).toEqual(0);
+        expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.message).toEqual("OK");
     });
 
@@ -46,8 +49,8 @@ describe("TwoFactorReportUseCase", () => {
 
         const result = await useCase.execute(false);
 
-        expect(result.report.invalidUsersCount).toEqual(0);
-        expect(result.report.listOfAffectedUsers).toEqual([]);
+        expect(result.report.invalidTwoFACount).toEqual(0);
+        expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.message).toEqual("OK");
     });
     
@@ -58,8 +61,8 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
-        expect(result.report.invalidUsersCount).toEqual(1);
-        expect(result.report.listOfAffectedUsers).toEqual([expectedReport]);
+        expect(result.report.invalidTwoFACount).toEqual(1);
+        expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
         expect(result.message).toEqual("OK");
     });
     
@@ -69,8 +72,8 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
-        expect(result.report.invalidUsersCount).toEqual(1);
-        expect(result.report.listOfAffectedUsers).toEqual([expectedReport]);
+        expect(result.report.invalidTwoFACount).toEqual(1);
+        expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
         expect(result.message).toEqual("OK");
     });
     
@@ -83,8 +86,8 @@ describe("TwoFactorReportUseCase", () => {
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
         ];
-        expect(result.report.invalidUsersCount).toEqual(2);
-        expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+        expect(result.report.invalidTwoFACount).toEqual(2);
+        expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
     
@@ -94,8 +97,8 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-        expect(result.report.invalidUsersCount).toEqual(1);
-        expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+        expect(result.report.invalidTwoFACount).toEqual(1);
+        expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
 
@@ -105,27 +108,19 @@ describe("TwoFactorReportUseCase", () => {
 
     const result = await useCase.execute(true);
 
-    expect(result.report.invalidUsersCount).toEqual(0);
-    expect(result.report.listOfAffectedUsers).toEqual([]);
+    expect(result.report.invalidTwoFACount).toEqual(0);
+    expect(result.report.invalidTwoFAList).toEqual([]);
+    expect(result.disableUsersMessage).contain("No users found.");
     expect(result.message).toBe("OK");
 }); 
-    
-    it("Should throw exception if no users in the given usergroup", async () => {
-        const useCase = givenInvalidUserGroupId();
-        
-        await expect(async () => {
-            await useCase.execute(false);
-        }).rejects.toThrow(NonUsersException);
-    });
-
     it("Should ignore disabled users if only exist disabled users", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
     const useCase = givenUsersWithConfig([userWithTwoFA, disabledUser], default_config);
 
     const result = await useCase.execute(true);
 
-    expect(result.report.invalidUsersCount).toEqual(0);
-    expect(result.report.listOfAffectedUsers).toEqual([]);
+    expect(result.report.invalidTwoFACount).toEqual(0);
+    expect(result.report.invalidTwoFAList).toEqual([]);
 }); 
 
     it("Should report 1 user if two exist without twoFA but only 1 is enabled", async () => {
@@ -135,8 +130,8 @@ describe("TwoFactorReportUseCase", () => {
     const result = await useCase.execute(true);
 
     const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-    expect(result.report.invalidUsersCount).toEqual(1);
-    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+    expect(result.report.invalidTwoFACount).toEqual(1);
+    expect(result.report.invalidTwoFAList).toEqual(expectedReport);
     expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
 });
 
@@ -147,25 +142,79 @@ describe("TwoFactorReportUseCase", () => {
     const result = await useCase.execute(false);
 
     const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-    expect(result.report.invalidUsersCount).toEqual(1);
-    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+    expect(result.report.invalidTwoFACount).toEqual(1);
+    expect(result.report.invalidTwoFAList).toEqual(expectedReport);
     expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
 }); 
 
-    it("Should report Disabled users action is not executed due not invalid users found If disabledInvalid is true but all users are disabled", async () => {
+    it("Should report Disabled users action is not executed due to no invalid users found. If disabledInvalid is true but all users are disabled", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
     const useCase = givenUsersWithConfig([disabledUser, userWithoutTwoFAdisabled], default_config);
 
     const result = await useCase.execute(true);
 
-    expect(result.report.invalidUsersCount).toEqual(0); 
-    expect(result.disableUsersMessage).toContain("Disabled users action is not executed due not invalid users found.");
+    expect(result.report.invalidTwoFACount).toEqual(0); 
+    expect(result.disableUsersMessage).toContain("Disabled users action is not executed due to no invalid users found.");
 }); 
+
+it("Should not fail if whoAccountGroup is undefined", async () => {
+    const configWithoutWHO = { ...default_config, whoAccountGroup: undefined };
+    const useCase = givenUsersWithConfig([userWithoutTwoFA], configWithoutWHO);
+
+    const result = await useCase.execute(false);
+
+    expect(result.report.invalidWhoCount).toBe(0);
+    expect(result.report.invalidWhoList).toEqual([]);
+});
+
+it("Should report WHO-invalid users correctly", async () => {
+    const useCase = givenUsersWithConfig([userWithoutExternalAuth], default_config);
+
+    const result = await useCase.execute(false);
+
+    expect(result.report.invalidWhoCount).toBe(1);
+    expect(result.report.invalidWhoList).toEqual([
+        { id: userWithoutExternalAuth.id, name: userWithoutExternalAuth.username }
+    ]);
+});
+
+it("Should report auth-invalid users correctly (not in 2FA or WHO)", async () => {
+    const useCase = givenUsersWithConfig([userInvalidAuth], default_config);
+
+    const result = await useCase.execute(false);
+
+    expect(result.report.invalidAuthCount).toBe(1);
+    expect(result.report.invalidAuthList).toEqual([
+        { id: userInvalidAuth.id, name: userInvalidAuth.username }
+    ]);
+});
+
+it("Should classify users into correct invalid categories (2FA, WHO, AUTH)", async () => {
+    const useCase = givenUsersWithConfig(mixedInvalidUsers, default_config);
+
+    const result = await useCase.execute(false);
+
+    expect(result.report.invalidTwoFACount).toBe(1);
+    expect(result.report.invalidWhoCount).toBe(1);
+    expect(result.report.invalidAuthCount).toBe(1);
+
+    expect(result.report.invalidTwoFAList).toEqual([
+        { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }
+    ]);
+    expect(result.report.invalidWhoList).toEqual([
+        { id: userWithoutExternalAuth.id, name: userWithoutExternalAuth.username }
+    ]);
+    expect(result.report.invalidAuthList).toEqual([
+        { id: userInvalidAuth.id, name: userInvalidAuth.username }
+    ]);
+});
+
+
 });
 
 function givenUsersWithConfig(users: TwoFactorUser[], config = default_config) {
     const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository(users, config.twoFactorGroup.id),
+        givenUserRepository(users),
         givenTwoFactorReportD2Repository(),
         givenConfigRepository(config),
         givenUserMonitoringProgramD2Repository()
@@ -176,7 +225,7 @@ function givenUsersWithConfig(users: TwoFactorUser[], config = default_config) {
 
 function givenUsers(users: TwoFactorUser[]) {
     const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository(users, default_config.twoFactorGroup.id),
+        givenUserRepository(users),
         givenTwoFactorReportD2Repository(),
         givenConfigRepository(),
         givenUserMonitoringProgramD2Repository()
@@ -186,7 +235,7 @@ function givenUsers(users: TwoFactorUser[]) {
 
 function givenInvalidUserGroupId() {
     const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository([], "invalidGroupId"),
+        givenUserRepository([], ["invalidGroupId"]),
         givenTwoFactorReportD2Repository(),
         givenConfigRepository(),
         givenUserMonitoringProgramD2Repository()
@@ -194,9 +243,9 @@ function givenInvalidUserGroupId() {
     return useCase;
 }
 
-function givenUserRepository(users: TwoFactorUser[], groupId = default_config.twoFactorGroup.id) {
+function givenUserRepository(users: TwoFactorUser[], excludedGroupIds =  default_config.exceptionGroup?.map(group => group.id) ?? []) {
     const mockedRepository = mock(TwoFactorUserD2Repository);
-    when(mockedRepository.getUsersByGroupId(deepEqual([groupId]))).thenReturn(Promise.resolve(users));
+    when(mockedRepository.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenReturn(Promise.resolve(users));
     when(mockedRepository.disableUsers(anything())).thenReturn(Promise.resolve("Disabled users action is enabled and executed."));
     const configRepository = instance(mockedRepository);
     return configRepository;

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -50,13 +50,11 @@ const alternativeConfig: TwoFactorUserOptions = {
         id: "MkELexlZOj8",
         name: "Who account usergroup",
     },
-    exceptionGroup: [
-    ]
+    exceptionGroup: [],
 };
 
-const useCaseOptionsDisabledFalse = {shouldDisableInvalidUsers: false}
-const useCaseOptionsDisabledTrue = {shouldDisableInvalidUsers: true}
-
+const useCaseOptionsDisabledFalse = { shouldDisableInvalidUsers: false };
+const useCaseOptionsDisabledTrue = { shouldDisableInvalidUsers: true };
 
 describe("TwoFactorReportUseCase", () => {
     it("Should detects a user in 2FA group with twoFA disabled as invalidTwoFA", async () => {
@@ -68,7 +66,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute({shouldDisableInvalidUsers: false});
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false });
 
         expect(result.report.invalidTwoFAList).toEqual([{ id: "u1", name: "testuser" }]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -85,7 +83,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute({shouldDisableInvalidUsers: false});
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false });
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -197,7 +197,6 @@ describe("TwoFactorReportUseCase", () => {
 
         const result = await useCase.execute(false);
 
-        expect(result.report.invalidTwoFACount).toEqual(0);
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.message).toEqual("OK");
     });
@@ -208,7 +207,6 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
-        expect(result.report.invalidTwoFACount).toEqual(1);
         expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
         expect(result.message).toEqual("OK");
     });
@@ -222,7 +220,6 @@ describe("TwoFactorReportUseCase", () => {
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
         ];
-        expect(result.report.invalidTwoFACount).toEqual(2);
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
@@ -233,7 +230,6 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-        expect(result.report.invalidTwoFACount).toEqual(1);
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
@@ -244,7 +240,6 @@ describe("TwoFactorReportUseCase", () => {
 
         const result = await useCase.execute(true);
 
-        expect(result.report.invalidTwoFACount).toEqual(0);
         expect(result.report.invalidTwoFAList).toEqual([]);
     });
 
@@ -258,7 +253,6 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(true);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-        expect(result.report.invalidTwoFACount).toEqual(1);
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
     });
@@ -273,7 +267,6 @@ describe("TwoFactorReportUseCase", () => {
         const result = await useCase.execute(false);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-        expect(result.report.invalidTwoFACount).toEqual(1);
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
         expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
     });
@@ -282,10 +275,6 @@ describe("TwoFactorReportUseCase", () => {
         const useCase = createUseCase({ users: mixedInvalidUsers, config: alternativeConfig });
 
         const result = await useCase.execute(false);
-
-        expect(result.report.invalidTwoFACount).toBe(1);
-        expect(result.report.invalidWhoCount).toBe(1);
-        expect(result.report.invalidAuthCount).toBe(1);
 
         expect(result.report.invalidTwoFAList).toEqual([
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -54,6 +54,9 @@ const alternativeConfig: TwoFactorUserOptions = {
     ]
 };
 
+const useCaseOptionsDisabledFalse = {shouldDisableInvalidUsers: false}
+const useCaseOptionsDisabledTrue = {shouldDisableInvalidUsers: true}
+
 
 describe("TwoFactorReportUseCase", () => {
     it("Should detects a user in 2FA group with twoFA disabled as invalidTwoFA", async () => {
@@ -65,7 +68,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute({shouldDisableInvalidUsers: false});
 
         expect(result.report.invalidTwoFAList).toEqual([{ id: "u1", name: "testuser" }]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -82,7 +85,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute({shouldDisableInvalidUsers: false});
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -97,7 +100,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([{ id: "u2", name: "testuser" }]);
@@ -112,7 +115,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -127,7 +130,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -145,7 +148,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([{ id: "u5", name: "testuser" }]);
         expect(result.report.invalidWhoList).toEqual([{ id: "u5", name: "testuser" }]);
@@ -164,7 +167,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([{ id: "u5", name: "testuser" }]);
@@ -183,7 +186,7 @@ describe("TwoFactorReportUseCase", () => {
         };
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -195,7 +198,7 @@ describe("TwoFactorReportUseCase", () => {
             users: [userWithTwoFA, userWithTwoFA, userInTwoFAGroupButWithExternalAuth],
         });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.message).toEqual("OK");
@@ -204,7 +207,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 1 affected user if we provide a list with two users, and only one has two-factor authentication disabled.", async () => {
         const useCase = createUseCase({ users: listOfUsersOneValidOneInvalid });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
         expect(result.report.invalidTwoFAList).toEqual([expectedReport]);
@@ -214,7 +217,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 2 affected users and a list of 2 affected user if 2 user has two factor deactivate and 1 activated", async () => {
         const useCase = createUseCase({ users: listOfUsersWithTwoInvalid });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         const expectedReport = [
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
@@ -227,7 +230,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 1 affected users and a list of 1 affected user if 1 user has two factor deactivate and 2 activated", async () => {
         const useCase = createUseCase({ users: listOfUsersWithTwoValid });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
@@ -238,7 +241,7 @@ describe("TwoFactorReportUseCase", () => {
         const disabledUser = { ...userWithoutTwoFA, disabled: true };
         const useCase = createUseCase({ users: [userWithTwoFA, disabledUser], config: alternativeConfig });
 
-        const result = await useCase.execute(true);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([]);
     });
@@ -250,7 +253,7 @@ describe("TwoFactorReportUseCase", () => {
             config: alternativeConfig,
         });
 
-        const result = await useCase.execute(true);
+        const result = await useCase.execute(useCaseOptionsDisabledTrue);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
@@ -264,7 +267,7 @@ describe("TwoFactorReportUseCase", () => {
             config: alternativeConfig,
         });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
         expect(result.report.invalidTwoFAList).toEqual(expectedReport);
@@ -274,7 +277,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should classify users into correct invalid categories (2FA, WHO, AUTH)", async () => {
         const useCase = createUseCase({ users: mixedInvalidUsers, config: alternativeConfig });
 
-        const result = await useCase.execute(false);
+        const result = await useCase.execute(useCaseOptionsDisabledFalse);
 
         expect(result.report.invalidTwoFAList).toEqual([
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -4,11 +4,14 @@ import { RunTwoFactorReportUseCase } from "../RunTwoFactorReportUseCase";
 import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
 import { anything, deepEqual, instance, mock, when } from "ts-mockito";
 import {
-    config,
+    config_exception_and_disabled,
+    default_config,
+    disable_users_config,
     listOfUsers,
     listOfUsersWithTwoInvalid,
     listOfUsersWithTwoValid,
     userWithoutTwoFA,
+    userWithoutTwoFAdisabled,
     userWithTwoFA,
 } from "./TwoFactorTest.data";
 import { TwoFactorUserD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository";
@@ -16,6 +19,7 @@ import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-mon
 import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { NonUsersException } from "domain/entities/user-monitoring/two-factor-monitoring/exception/NonUsersException";
+import { TwoFactorUserOptions } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions";
 
 describe("TwoFactorReportUseCase", () => {
     it("Should push report with 0 affected users and empty affected user list if one user has two factor activated", async () => {
@@ -37,6 +41,17 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.report.listOfAffectedUsers).toEqual([]);
         expect(result.message).toEqual("OK");
     });
+
+    it("Should push report with 0 affected users and empty affected user list if all the users has no two factor activated", async () => {
+        const useCase = givenUsers([userWithTwoFA, userWithTwoFA]);
+
+        const result = await useCase.execute();
+
+        expect(result.report.invalidUsersCount).toEqual(0);
+        expect(result.report.listOfAffectedUsers).toEqual([]);
+        expect(result.message).toEqual("OK");
+    });
+    
     
     it("Should push report with 1 affected users and 1 affected user list if 1 user has two factor deactivated", async () => {
         const useCase = givenUsers([userWithoutTwoFA]);
@@ -84,6 +99,17 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
         expect(result.message).toEqual("OK");
     });
+
+    it("Should report 0 users if reported users was in exception usergroup", async () => {
+    const disabledUser = { ...userWithoutTwoFA, disabled: true };
+    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], config_exception_and_disabled);
+
+    const result = await useCase.execute();
+
+    expect(result.report.invalidUsersCount).toEqual(0);
+    expect(result.report.listOfAffectedUsers).toEqual([]);
+    expect(result.message).toBe("OK");
+}); 
     
     it("Should throw exception if no users in the given usergroup", async () => {
         const useCase = givenInvalidUserGroupId();
@@ -92,17 +118,74 @@ describe("TwoFactorReportUseCase", () => {
             await useCase.execute();
         }).rejects.toThrow(NonUsersException);
     });
+
+    it("Should ignore disabled users if only exist disabled users", async () => {
+    const disabledUser = { ...userWithoutTwoFA, disabled: true };
+    const useCase = givenUsersWithConfig([userWithTwoFA, disabledUser], disable_users_config);
+
+    const result = await useCase.execute();
+
+    expect(result.report.invalidUsersCount).toEqual(0);
+    expect(result.report.listOfAffectedUsers).toEqual([]);
+}); 
+
+    it("Should report 1 user if two exist without twoFA but only 1 is enabled", async () => {
+    const disabledUser = { ...userWithoutTwoFA, disabled: true };
+    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], disable_users_config);
+
+    const result = await useCase.execute();
+
+    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
+    expect(result.report.invalidUsersCount).toEqual(1);
+    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+}); 
+
+    it("Should report Disabled users action is not enabled. If disabledInvalid is false", async () => {
+    const disabledUser = { ...userWithoutTwoFA, disabled: true };
+    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], default_config);
+
+    const result = await useCase.execute();
+
+    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
+    expect(result.report.invalidUsersCount).toEqual(1);
+    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+    expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
+}); 
+
+    it("Should report Disabled users action executed If disabledInvalid is true", async () => {
+    const disabledUser = { ...userWithoutTwoFA, disabled: true };
+    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], disable_users_config);
+
+    const result = await useCase.execute();
+
+    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
+    expect(result.report.invalidUsersCount).toEqual(1);
+    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
+    expect(result.disableUsersMessage).toContain("Disabled users action is enabled and executed.");
+}); 
 });
+
+function givenUsersWithConfig(users: TwoFactorUser[], config = default_config) {
+    const useCase = new RunTwoFactorReportUseCase(
+        givenUserRepository(users, config.twoFactorGroup.id),
+        givenTwoFactorReportD2Repository(),
+        givenConfigRepository(config),
+        givenUserMonitoringProgramD2Repository()
+    );
+    return useCase;
+}
+
 
 function givenUsers(users: TwoFactorUser[]) {
     const useCase = new RunTwoFactorReportUseCase(
-        givenUserRepository(users, config.twoFactorGroup.id),
+        givenUserRepository(users, default_config.twoFactorGroup.id),
         givenTwoFactorReportD2Repository(),
         givenConfigRepository(),
         givenUserMonitoringProgramD2Repository()
     );
     return useCase;
 }
+
 function givenInvalidUserGroupId() {
     const useCase = new RunTwoFactorReportUseCase(
         givenUserRepository([], "invalidGroupId"),
@@ -113,9 +196,10 @@ function givenInvalidUserGroupId() {
     return useCase;
 }
 
-function givenUserRepository(users: TwoFactorUser[], groupId = config.twoFactorGroup.id) {
+function givenUserRepository(users: TwoFactorUser[], groupId = default_config.twoFactorGroup.id) {
     const mockedRepository = mock(TwoFactorUserD2Repository);
     when(mockedRepository.getUsersByGroupId(deepEqual([groupId]))).thenReturn(Promise.resolve(users));
+    when(mockedRepository.disableUsers(anything())).thenReturn(Promise.resolve("Disabled users action is enabled and executed."));
     const configRepository = instance(mockedRepository);
     return configRepository;
 }
@@ -131,7 +215,7 @@ function givenUserMonitoringProgramD2Repository() {
     return reportRepository;
 }
 
-function givenConfigRepository() {
+function givenConfigRepository(config: TwoFactorUserOptions = default_config) {
     const mockedRepository = mock(TwoFactorConfigD2Repository);
     when(mockedRepository.get()).thenReturn(Promise.resolve(config));
     const configRepository = instance(mockedRepository);

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -6,7 +6,6 @@ import { anything, deepEqual, instance, mock, when } from "ts-mockito";
 import {
     config_exception_and_disabled,
     default_config,
-    disable_users_config,
     listOfUsers,
     listOfUsersWithTwoInvalid,
     listOfUsersWithTwoValid,
@@ -25,7 +24,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report with 0 affected users and empty affected user list if one user has two factor activated", async () => {
         const useCase = givenUsers([userWithTwoFA]);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         expect(result.report.invalidUsersCount).toEqual(0);
         expect(result.report.listOfAffectedUsers).toEqual([]);
@@ -35,7 +34,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report with 0 affected users and empty affected user list if all the users has two factor activated", async () => {
         const useCase = givenUsers([userWithTwoFA, userWithTwoFA]);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         expect(result.report.invalidUsersCount).toEqual(0);
         expect(result.report.listOfAffectedUsers).toEqual([]);
@@ -45,7 +44,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report with 0 affected users and empty affected user list if all the users has no two factor activated", async () => {
         const useCase = givenUsers([userWithTwoFA, userWithTwoFA]);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         expect(result.report.invalidUsersCount).toEqual(0);
         expect(result.report.listOfAffectedUsers).toEqual([]);
@@ -56,7 +55,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report with 1 affected users and 1 affected user list if 1 user has two factor deactivated", async () => {
         const useCase = givenUsers([userWithoutTwoFA]);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
         expect(result.report.invalidUsersCount).toEqual(1);
@@ -67,7 +66,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 1 affected user if we provide a list with two users, and only one has two-factor authentication disabled.", async () => {
         const useCase = givenUsers(listOfUsers);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         const expectedReport = { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username };
         expect(result.report.invalidUsersCount).toEqual(1);
@@ -78,7 +77,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 2 affected users and a list of 2 affected user if 2 user has two factor deactivate and 1 activated", async () => {
         const useCase = givenUsers(listOfUsersWithTwoInvalid);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         const expectedReport = [
             { id: userWithoutTwoFA.id, name: userWithoutTwoFA.username },
@@ -92,7 +91,7 @@ describe("TwoFactorReportUseCase", () => {
     it("Should push report 1 affected users and a list of 1 affected user if 1 user has two factor deactivate and 2 activated", async () => {
         const useCase = givenUsers(listOfUsersWithTwoValid);
 
-        const result = await useCase.execute();
+        const result = await useCase.execute(false);
 
         const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
         expect(result.report.invalidUsersCount).toEqual(1);
@@ -104,7 +103,7 @@ describe("TwoFactorReportUseCase", () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
     const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], config_exception_and_disabled);
 
-    const result = await useCase.execute();
+    const result = await useCase.execute(true);
 
     expect(result.report.invalidUsersCount).toEqual(0);
     expect(result.report.listOfAffectedUsers).toEqual([]);
@@ -115,15 +114,15 @@ describe("TwoFactorReportUseCase", () => {
         const useCase = givenInvalidUserGroupId();
         
         await expect(async () => {
-            await useCase.execute();
+            await useCase.execute(false);
         }).rejects.toThrow(NonUsersException);
     });
 
     it("Should ignore disabled users if only exist disabled users", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithTwoFA, disabledUser], disable_users_config);
+    const useCase = givenUsersWithConfig([userWithTwoFA, disabledUser], default_config);
 
-    const result = await useCase.execute();
+    const result = await useCase.execute(true);
 
     expect(result.report.invalidUsersCount).toEqual(0);
     expect(result.report.listOfAffectedUsers).toEqual([]);
@@ -131,20 +130,21 @@ describe("TwoFactorReportUseCase", () => {
 
     it("Should report 1 user if two exist without twoFA but only 1 is enabled", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], disable_users_config);
+    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], default_config);
 
-    const result = await useCase.execute();
+    const result = await useCase.execute(true);
 
     const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
     expect(result.report.invalidUsersCount).toEqual(1);
     expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
-}); 
+    expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
+});
 
     it("Should report Disabled users action is not enabled. If disabledInvalid is false", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
     const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], default_config);
 
-    const result = await useCase.execute();
+    const result = await useCase.execute(false);
 
     const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
     expect(result.report.invalidUsersCount).toEqual(1);
@@ -152,16 +152,14 @@ describe("TwoFactorReportUseCase", () => {
     expect(result.disableUsersMessage).toEqual("Disabled users action is not enabled.");
 }); 
 
-    it("Should report Disabled users action executed If disabledInvalid is true", async () => {
+    it("Should report Disabled users action is not executed due not invalid users found If disabledInvalid is true but all users are disabled", async () => {
     const disabledUser = { ...userWithoutTwoFA, disabled: true };
-    const useCase = givenUsersWithConfig([userWithoutTwoFA, disabledUser, userWithoutTwoFAdisabled], disable_users_config);
+    const useCase = givenUsersWithConfig([disabledUser, userWithoutTwoFAdisabled], default_config);
 
-    const result = await useCase.execute();
+    const result = await useCase.execute(true);
 
-    const expectedReport = [{ id: userWithoutTwoFA.id, name: userWithoutTwoFA.username }];
-    expect(result.report.invalidUsersCount).toEqual(1);
-    expect(result.report.listOfAffectedUsers).toEqual(expectedReport);
-    expect(result.disableUsersMessage).toContain("Disabled users action is enabled and executed.");
+    expect(result.report.invalidUsersCount).toEqual(0); 
+    expect(result.disableUsersMessage).toContain("Disabled users action is not executed due not invalid users found.");
 }); 
 });
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -1,7 +1,7 @@
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { TwoFactorUserOptions } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions";
 
-export const config: TwoFactorUserOptions = {
+const common_config = {
     pushProgram: {
         id: "IKpEgoQ4S0r",
         name: "Event program uid",
@@ -12,6 +12,37 @@ export const config: TwoFactorUserOptions = {
     },
 };
 
+export const default_config: TwoFactorUserOptions = {
+    ...common_config,
+    config: {
+    disableInvalid: false,
+    exceptionGroup: [
+    ]
+  },
+};
+
+export const disable_users_config: TwoFactorUserOptions = {
+    ...common_config,
+    config: {
+    disableInvalid: true,
+    exceptionGroup: [
+    ]
+  },
+};
+
+export const config_exception_and_disabled: TwoFactorUserOptions = {
+    ...common_config,
+    config: {
+    disableInvalid: true,
+    exceptionGroup: [
+      {
+        id: "dummy_uid",
+        name: "dummy_group_name"
+      }
+    ]
+  },
+};
+
 export const NoUsersReport = {
     invalidUsersCount: 0,
     listOfAffectedUsers: [],
@@ -20,14 +51,50 @@ export const NoUsersReport = {
 export const userWithTwoFA: TwoFactorUser = {
     id: "userUid",
     twoFA: true,
+    disabled: false,
     username: "username",
+    externalAuth: false,
+    userGroups: [ {
+        id: "dummy_uid",
+        name: "dummy_group_name"
+      }],
 };
 
 export const userWithoutTwoFA: TwoFactorUser = {
     id: "userUid2",
     twoFA: false,
+    disabled: false,
     username: "username2",
+    externalAuth: false,
+    userGroups: [ {
+        id: "dummy_uid",
+        name: "dummy_group_name"
+      }],
 };
+
+export const userWithTwoFAdisabled: TwoFactorUser = {
+    id: "userUid",
+    twoFA: true,
+    disabled: true,
+    username: "username",
+    externalAuth: false,
+    userGroups: [ {
+        id: "dummy_uid",
+        name: "dummy_group_name"
+      }],
+};
+export const userWithoutTwoFAdisabled: TwoFactorUser = {
+    id: "userUid2",
+    twoFA: false,
+    disabled: true,
+    username: "username2",
+    externalAuth: false,
+    userGroups: [ {
+        id: "dummy_uid",
+        name: "dummy_group_name"
+      }],
+};
+
 
 export const listOfUsers: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA];
 export const listOfUsersWithTwoInvalid: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA, userWithoutTwoFA];

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -11,10 +11,12 @@ export const userWithTwoFA: TwoFactorUser = {
     disabled: false,
     username: "username",
     externalAuth: false,
-    userGroups: [ {
-        id: "MkELexlZOj9",
-        name: "dummy_group_name"
-      }],
+    userGroups: [
+        {
+            id: "MkELexlZOj9",
+            name: "dummy_group_name",
+        },
+    ],
 };
 
 export const userInTwoFAGroupButWithExternalAuth: TwoFactorUser = {
@@ -23,10 +25,12 @@ export const userInTwoFAGroupButWithExternalAuth: TwoFactorUser = {
     disabled: false,
     username: "username",
     externalAuth: true,
-    userGroups: [ {
-        id: "MkELexlZOj9",
-        name: "dummy_group_name"
-      }],
+    userGroups: [
+        {
+            id: "MkELexlZOj9",
+            name: "dummy_group_name",
+        },
+    ],
 };
 
 export const userWithoutTwoFA: TwoFactorUser = {
@@ -35,10 +39,12 @@ export const userWithoutTwoFA: TwoFactorUser = {
     disabled: false,
     username: "username2",
     externalAuth: false,
-    userGroups: [ {
-        id: "MkELexlZOj9",
-        name: "dummy_group_name"
-      }],
+    userGroups: [
+        {
+            id: "MkELexlZOj9",
+            name: "dummy_group_name",
+        },
+    ],
 };
 
 export const userWithTwoFAdisabled: TwoFactorUser = {
@@ -47,10 +53,12 @@ export const userWithTwoFAdisabled: TwoFactorUser = {
     disabled: true,
     username: "username",
     externalAuth: false,
-    userGroups: [ {
-        id: "MkELexlZOj9",
-        name: "dummy_group_name"
-      }],
+    userGroups: [
+        {
+            id: "MkELexlZOj9",
+            name: "dummy_group_name",
+        },
+    ],
 };
 export const userWithoutTwoFAdisabled: TwoFactorUser = {
     id: "userUid2",
@@ -58,10 +66,12 @@ export const userWithoutTwoFAdisabled: TwoFactorUser = {
     disabled: true,
     username: "username2",
     externalAuth: false,
-    userGroups: [ {
-        id: "MkELexlZOj9",
-        name: "dummy_group_name"
-      }],
+    userGroups: [
+        {
+            id: "MkELexlZOj9",
+            name: "dummy_group_name",
+        },
+    ],
 };
 
 export const userWithoutExternalAuth: TwoFactorUser = {
@@ -73,8 +83,8 @@ export const userWithoutExternalAuth: TwoFactorUser = {
     userGroups: [
         {
             id: "MkELexlZOj8",
-            name: "Who account usergroup"
-        }
+            name: "Who account usergroup",
+        },
     ],
 };
 
@@ -84,15 +94,14 @@ export const userInvalidAuth: TwoFactorUser = {
     disabled: false,
     username: "username4",
     externalAuth: false,
-    userGroups: []
+    userGroups: [],
 };
 
 export const mixedInvalidUsers: TwoFactorUser[] = [
-    userWithoutTwoFA,        // 2FA invalid
+    userWithoutTwoFA, // 2FA invalid
     userWithoutExternalAuth, // WHO invalid
-    userInvalidAuth          // Auth invalid
+    userInvalidAuth, // Auth invalid
 ];
-
 
 export const listOfUsersOneValidOneInvalid: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA];
 export const listOfUsersWithTwoInvalid: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA, userWithoutTwoFA];

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -1,36 +1,4 @@
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
-import { TwoFactorUserOptions } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions";
-
-const common_config = {
-    pushProgram: {
-        id: "IKpEgoQ4S0r",
-        name: "Event program uid",
-    },
-    twoFactorGroup: {
-        id: "MkELexlZOj9",
-        name: "TwoFactor usergroup",
-    },
-    whoAccountGroup: {
-        id: "MkELexlZOj8",
-        name: "Who account usergroup",
-    }
-};
-
-export const default_config: TwoFactorUserOptions = {
-    ...common_config,
-    exceptionGroup: [
-    ]
-};
-
-export const config_exception_and_disabled: TwoFactorUserOptions = {
-    ...common_config,
-    exceptionGroup: [
-      {
-        id: "dummy_uid",
-        name: "dummy_group_name"
-      }
-    ]
-};
 
 export const NoUsersReport = {
     invalidUsersCount: 0,
@@ -43,6 +11,18 @@ export const userWithTwoFA: TwoFactorUser = {
     disabled: false,
     username: "username",
     externalAuth: false,
+    userGroups: [ {
+        id: "MkELexlZOj9",
+        name: "dummy_group_name"
+      }],
+};
+
+export const userInTwoFAGroupButWithExternalAuth: TwoFactorUser = {
+    id: "userUid",
+    twoFA: false,
+    disabled: false,
+    username: "username",
+    externalAuth: true,
     userGroups: [ {
         id: "MkELexlZOj9",
         name: "dummy_group_name"
@@ -114,6 +94,6 @@ export const mixedInvalidUsers: TwoFactorUser[] = [
 ];
 
 
-export const listOfUsers: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA];
+export const listOfUsersOneValidOneInvalid: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA];
 export const listOfUsersWithTwoInvalid: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA, userWithoutTwoFA];
 export const listOfUsersWithTwoValid: TwoFactorUser[] = [userWithTwoFA, userWithTwoFA, userWithoutTwoFA];

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -10,26 +10,26 @@ const common_config = {
         id: "MkELexlZOj9",
         name: "TwoFactor usergroup",
     },
+    whoAccountGroup: {
+        id: "MkELexlZOj8",
+        name: "Who account usergroup",
+    }
 };
 
 export const default_config: TwoFactorUserOptions = {
     ...common_config,
-    config: {
     exceptionGroup: [
     ]
-  },
 };
 
 export const config_exception_and_disabled: TwoFactorUserOptions = {
     ...common_config,
-    config: {
     exceptionGroup: [
       {
         id: "dummy_uid",
         name: "dummy_group_name"
       }
     ]
-  },
 };
 
 export const NoUsersReport = {
@@ -44,7 +44,7 @@ export const userWithTwoFA: TwoFactorUser = {
     username: "username",
     externalAuth: false,
     userGroups: [ {
-        id: "dummy_uid",
+        id: "MkELexlZOj9",
         name: "dummy_group_name"
       }],
 };
@@ -56,7 +56,7 @@ export const userWithoutTwoFA: TwoFactorUser = {
     username: "username2",
     externalAuth: false,
     userGroups: [ {
-        id: "dummy_uid",
+        id: "MkELexlZOj9",
         name: "dummy_group_name"
       }],
 };
@@ -68,7 +68,7 @@ export const userWithTwoFAdisabled: TwoFactorUser = {
     username: "username",
     externalAuth: false,
     userGroups: [ {
-        id: "dummy_uid",
+        id: "MkELexlZOj9",
         name: "dummy_group_name"
       }],
 };
@@ -79,10 +79,39 @@ export const userWithoutTwoFAdisabled: TwoFactorUser = {
     username: "username2",
     externalAuth: false,
     userGroups: [ {
-        id: "dummy_uid",
+        id: "MkELexlZOj9",
         name: "dummy_group_name"
       }],
 };
+
+export const userWithoutExternalAuth: TwoFactorUser = {
+    id: "userUid3",
+    twoFA: true,
+    disabled: false,
+    username: "username3",
+    externalAuth: false,
+    userGroups: [
+        {
+            id: "MkELexlZOj8",
+            name: "Who account usergroup"
+        }
+    ],
+};
+
+export const userInvalidAuth: TwoFactorUser = {
+    id: "userUid4",
+    twoFA: false,
+    disabled: false,
+    username: "username4",
+    externalAuth: false,
+    userGroups: []
+};
+
+export const mixedInvalidUsers: TwoFactorUser[] = [
+    userWithoutTwoFA,        // 2FA invalid
+    userWithoutExternalAuth, // WHO invalid
+    userInvalidAuth          // Auth invalid
+];
 
 
 export const listOfUsers: TwoFactorUser[] = [userWithTwoFA, userWithoutTwoFA];

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -15,16 +15,6 @@ const common_config = {
 export const default_config: TwoFactorUserOptions = {
     ...common_config,
     config: {
-    disableInvalid: false,
-    exceptionGroup: [
-    ]
-  },
-};
-
-export const disable_users_config: TwoFactorUserOptions = {
-    ...common_config,
-    config: {
-    disableInvalid: true,
     exceptionGroup: [
     ]
   },
@@ -33,7 +23,6 @@ export const disable_users_config: TwoFactorUserOptions = {
 export const config_exception_and_disabled: TwoFactorUserOptions = {
     ...common_config,
     config: {
-    disableInvalid: true,
     exceptionGroup: [
       {
         id: "dummy_uid",

--- a/src/scripts/commands/userMonitoring.ts
+++ b/src/scripts/commands/userMonitoring.ts
@@ -54,6 +54,13 @@ const run2FAReporterCmd = command({
             long: "config-file",
             description: "Config file",
         }),
+        disableusers: flag({
+            type: boolean,
+            short: "d",
+            long: "disable-users",
+            description:
+                "Disable invalid twoFA users.",
+        }),
     },
 
     handler: async args => {
@@ -69,7 +76,7 @@ const run2FAReporterCmd = command({
             userMonitoringReportRepository,
             externalConfigRepository,
             programRepository
-        ).execute();
+        ).execute(args.disableusers);
 
         log.info(JSON.stringify(response));
     },

--- a/src/scripts/commands/userMonitoring.ts
+++ b/src/scripts/commands/userMonitoring.ts
@@ -77,7 +77,7 @@ const run2FAReporterCmd = command({
             userMonitoringReportRepository,
             externalConfigRepository,
             programRepository
-        ).execute(args.disableusers);
+        ).execute({ shouldDisableInvalidUsers: args.disableusers });
 
         log.info(JSON.stringify(response));
     },

--- a/src/scripts/commands/userMonitoring.ts
+++ b/src/scripts/commands/userMonitoring.ts
@@ -1,7 +1,9 @@
+import fs from "fs";
 import "json5/lib/register";
+import * as Codec from "purify-ts";
 import { command, subcommands, option, string, boolean, flag } from "cmd-ts";
 
-import { getD2Api } from "scripts/common";
+import { getD2ApiFromArgs } from "scripts/common";
 import log from "utils/log";
 
 import { RunTwoFactorReportUseCase } from "domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase";
@@ -30,6 +32,7 @@ import { MonitorUserGroupsUseCase } from "domain/usecases/user-monitoring/user-g
 import { UserD2Repository } from "data/user-monitoring/user-templates-monitoring/UserD2Repository";
 import { UserTemplatesMonitoringConfigD2Repository } from "data/user-monitoring/user-templates-monitoring/UserTemplatesMonitoringConfigD2Repository";
 import { MonitorUserTemplatesUseCase } from "domain/usecases/user-monitoring/user-templates-monitoring/MonitorUserTemplatesUseCase";
+import { D2Api } from "types/d2-api";
 
 export function getCommand() {
     return subcommands({
@@ -58,14 +61,12 @@ const run2FAReporterCmd = command({
             type: boolean,
             short: "d",
             long: "disable-users",
-            description:
-                "Disable invalid twoFA users.",
+            description: "Disable invalid twoFA users.",
         }),
     },
 
     handler: async args => {
-        const auth = getAuthFromFile(args.configFile);
-        const api = getD2Api(auth.apiurl);
+        const api = getApiFromConfigFile(args.configFile);
         const usersRepository = new TwoFactorUserD2Repository(api);
         const externalConfigRepository = new TwoFactorConfigD2Repository(api);
         const userMonitoringReportRepository = new TwoFactorReportD2Repository(api);
@@ -95,8 +96,7 @@ const runUsersMonitoringCmd = command({
     },
 
     handler: async args => {
-        const auth = getAuthFromFile(args.configFile);
-        const api = getD2Api(auth.apiurl);
+        const api = getApiFromConfigFile(args.configFile);
         const usersRepository = new PermissionFixerUserD2Repository(api);
         const userGroupsRepository = new PermissionFixerUserGroupD2Repository(api);
         const usersTemplateRepository = new PermissionFixerTemplateD2Repository(api);
@@ -135,9 +135,8 @@ const runAuthoritiesMonitoring = command({
     },
 
     handler: async args => {
-        const auth = getAuthFromFile(args.configFile);
+        const api = getApiFromConfigFile(args.configFile);
         const webhook = getWebhookConfFromFile(args.configFile);
-        const api = getD2Api(auth.apiurl);
         const UserRolesRepository = new UserRolesD2Repository(api);
         const externalConfigRepository = new AuthoritiesMonitoringConfigD2Repository(api);
         const messageRepository = new MessageMSTeamsRepository(webhook);
@@ -171,9 +170,8 @@ const runUserGroupMonitoringCmd = command({
     },
 
     handler: async args => {
-        const auth = getAuthFromFile(args.configFile);
+        const api = getApiFromConfigFile(args.configFile);
         const webhook = getWebhookConfFromFile(args.configFile);
-        const api = getD2Api(auth.apiurl);
 
         const userGroupsRepository = new UserGroupD2Repository(api);
         const externalConfigRepository = new UserGroupsMonitoringConfigD2Repository(api);
@@ -208,9 +206,8 @@ const runUserTemplateMonitoringCmd = command({
     },
 
     handler: async args => {
-        const auth = getAuthFromFile(args.configFile);
+        const api = getApiFromConfigFile(args.configFile);
         const webhook = getWebhookConfFromFile(args.configFile);
-        const api = getD2Api(auth.apiurl);
 
         const usersRepository = new UserD2Repository(api);
         const externalConfigRepository = new UserTemplatesMonitoringConfigD2Repository(api);
@@ -225,17 +222,31 @@ const runUserTemplateMonitoringCmd = command({
     },
 });
 
-function getAuthFromFile(configFile: string): UserMonitoringAuth {
-    const fs = require("fs");
-    const configJSON = JSON.parse(fs.readFileSync("./" + configFile, "utf8"));
-    const urlprefix = configJSON["URL"]["server"].split("//")[0] + "//";
-    const urlserver = configJSON["URL"]["server"].split("//")[1];
-    const apiurl: string =
-        urlprefix + configJSON["URL"]["username"] + ":" + configJSON["URL"]["password"] + "@" + urlserver;
+const localConfigCodec = Codec.Codec.interface({
+    URL: Codec.Codec.interface({
+        username: Codec.string,
+        password: Codec.string,
+        server: Codec.string,
+    }),
+});
 
-    return {
-        apiurl: apiurl,
-    };
+function getApiFromConfigFile(configFile: string): D2Api {
+    const configUnparsed = JSON.parse(fs.readFileSync(configFile, "utf8"));
+
+    return localConfigCodec.decode(configUnparsed).caseOf({
+        Left: errors => {
+            throw new Error(`Error parsing ${configFile}: ${errors}`);
+        },
+        Right: config => {
+            return getD2ApiFromArgs({
+                url: config["URL"]["server"],
+                auth: {
+                    username: config["URL"]["username"],
+                    password: config["URL"]["password"],
+                },
+            });
+        },
+    });
 }
 
 function getWebhookConfFromFile(configFile: string): MSTeamsWebhookOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,10 +280,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.18.0-beta.3":
-  version "1.18.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.18.0-beta.3.tgz#2f991727d8d90efb322579e07c819a2dc9f5ea9a"
-  integrity sha512-LdV8BFHrfWchKWeKL3A/saYBa4pP9e18ZiNkI6S4Kvj55cep2oVVaGocvWHTBkLupKWSV8bWSdq4pbpEXluEhg==
+"@eyeseetea/d2-api@1.18.0-beta.7":
+  version "1.18.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.18.0-beta.7.tgz#706286784eb0649ecddc2e6cf5a06928fd1a721d"
+  integrity sha512-FBXpVGvkw20MGixKRo1jkUdBc5/y1wj3nd/7sN9G7bfxu5YlE2VmD4hQ5XKgyGiATilgACx4Tz3gYMLERPaYEQ==
   dependencies:
     abort-controller "3.0.0"
     axios "1.6.4"


### PR DESCRIPTION
Required:
https://github.com/EyeSeeTea/d2-api/pull/171

The d2-api is updated and this branch could be merged, so this PR is ready to be taken out of draft.

It includes updated logic and tests to meet the new requirements:

- Detect users who have not enabled two-factor authentication.

- Disable those users if the --disable-users CLI flag is set.

It also expands the reporting to cover all authentication-related issues, including:

- WHO users without WHO external access enabled.

- Users belonging to both WHO and Two-Factor user groups.

- Any other invalid group combinations.

Previously, the report only listed users in the Two-Factor user group, which was not sufficient for the final workflow.

The functional test for approving this PR may not be necessary, as the code is already deployed to production and working as expected.