### PR TITLE
Feature/improve user monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ yarn start usermonitoring run-2fa-reporter --config-file config.json
 #### Debug:
 
 ```shell
-$ LOG_LEVEL=debug node --inspect-brk dist/index.js usermonitoring run-users-monitoring   --config-file config.json
+$ LOG_LEVEL=debug yarn tsx --inspect-brk src/index.ts usermonitoring run-permissions-fixer --config-file config.json 
 $ LOG_LEVEL=debug node --inspect-brk dist/index.js usermonitoring run-2fa-reporter   --config-file config.json
 ```
 

--- a/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
+++ b/src/data/user-monitoring/common/UserMonitoringFileResourceUtils.ts
@@ -13,7 +13,7 @@ export class UserMonitoringFileResourceUtils {
         const uniqueFilename = this.createUniqueFilename(name);
         log.info(`Saving file ${uniqueFilename}`);
         const jsonBlob = Buffer.from(jsonString, "utf-8");
-        if (jsonBlob.length === 0){
+        if (jsonBlob.length <= 2) {
             log.info("The file is empty.");
             return "";
         }
@@ -68,6 +68,7 @@ export class UserMonitoringFileResourceUtils {
         });
 
         await csvWriter.writeRecords(records);
+        log.info(`CSV file saved in ${filepath}.csv`);
     }
 }
 

--- a/src/data/user-monitoring/common/UserMonitoringProgramD2Repository.ts
+++ b/src/data/user-monitoring/common/UserMonitoringProgramD2Repository.ts
@@ -58,7 +58,7 @@ export class UserMonitoringProgramD2Repository implements UserMonitoringProgramR
         //todo use d2api filters
         const responses = await api
             .get<Programs>(
-                `/programs?filter=id:eq:${programUid}&fields=id,organisationUnits[id],programStages[id,programStageDataElements[id,dataElement[id,name,code]]&paging=false.json`
+                `/programs?filter=id:eq:${programUid}&fields=id,organisationUnits[id],programStages[id,programStageDataElements[id,dataElement[id,name,code]]&paging=false`
             )
             .getData();
 

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -25,8 +25,8 @@ const dataelement_file_valid_users_file_code = "ADMIN_valid_users_backup_4_Event
 
 const csvErrorFilename = `_users_backup`;
 const filenameErrorOnPush = `_users_push_error`;
-const filenameUsersPushed = `_users_pushed.json`;
-const filenameUserBackup = `_users_update_backup.json`;
+const filenameUsersPushed = `_users_pushed.txt`;
+const filenameUserBackup = `_users_update_backup.txt`;
 type ServerResponse = { status: string; typeReports: object[] };
 
 export class PermissionFixerReportD2Repository implements PermissionFixerReportRepository {

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -32,6 +32,23 @@ type ServerResponse = { status: string; typeReports: object[] };
 export class PermissionFixerReportD2Repository implements PermissionFixerReportRepository {
     constructor(private api: D2Api) {}
 
+    async saveEmptyReport(
+        program: UserMonitoringProgramMetadata
+    ): Async<string> {
+        log.info(`Saving report `);
+
+        const response = await this.pushEmptyReportToDhis(
+            this.api,
+            program
+        );
+
+        if (response?.status != "OK") {
+            throw new Error("Error on push report: " + JSON.stringify(response));
+        } else {
+            return response.status;
+        }
+    }
+
     async save(
         program: UserMonitoringProgramMetadata,
         responseGroups: PermissionFixerReport,
@@ -91,6 +108,65 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             userActionRequired,
             `${csvErrorFilename}`
         );
+    }
+
+    private async pushEmptyReportToDhis(
+        api: D2Api,
+        program: UserMonitoringProgramMetadata) {
+        log.info(`Create and Pushing report to DHIS2`);
+        const dataValues: UserMonitoringReportValues[] = program.dataElements
+            .map(item => {
+                switch (item.code) {
+                    case dataelement_invalid_users_groups_count_code:
+                        return { dataElement: item.id, value: 0 };
+                    case dataelement_invalid_roles_count_code:
+                        return { dataElement: item.id, value: 0 };
+                    case dataelement_users_pushed_code:
+                        return { dataElement: item.id, value: "No invalid users found." };
+                    default:
+                        return { dataElement: "", value: "" };
+                }
+            })
+            .filter(dataValue => dataValue.dataElement !== "");
+
+        if (dataValues.length == 0) {
+            log.info(`No data elements found`);
+            return;
+        }
+        log.info("Pushing report");
+
+        const response: ServerResponse = await api
+            .post<ServerResponse>(
+                "/tracker",
+                {
+                    async: false,
+                },
+                {
+                    events: [
+                        {
+                            program: program.id,
+                            programStage: program.programStageId,
+                            orgUnit: program.orgUnitId,
+                            occurredAt: new Date().toISOString(),
+                            dataValues: dataValues,
+                        },
+                    ],
+                }
+            )
+            .getData()
+            .catch(err => {
+                if (err?.response?.data) {
+                    log.error("Push ERROR ->");
+                    log.error(JSON.stringify(err.response.data));
+                    return err.response.data as ServerResponse;
+                } else {
+                    log.error("Push ERROR without any data");
+                    return { status: "ERROR", typeReports: [] };
+                }
+            });
+        log.info("Report sent status: " + response.status);
+
+        return response;
     }
 
     private async pushReportToDhis(

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -22,11 +22,13 @@ const dataelement_invalid_roles_list_code = "ADMIN_invalid_users_roles_usernames
 const dataelement_users_pushed_code = "ADMIN_user_pushed_control_Events";
 const dataelement_file_invalid_users_file_code = "ADMIN_invalid_users_backup_3_Events";
 const dataelement_file_valid_users_file_code = "ADMIN_valid_users_backup_4_Events";
+const dataelement_file_invalid_user_roles_file_code = "ADMIN_invalid_userroles_summary_13_Events";
 
 const csvErrorFilename = `_users_backup`;
 const filenameErrorOnPush = `_users_push_error`;
 const filenameUsersPushed = `_users_pushed.txt`;
 const filenameUserBackup = `_users_update_backup.txt`;
+const filenameUUserRolesSummary = `_users_removed_userroles_summary.txt`;
 type ServerResponse = { status: string; typeReports: object[] };
 
 export class PermissionFixerReportD2Repository implements PermissionFixerReportRepository {
@@ -71,8 +73,20 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             filenameUserBackup,
             this.api
         );
-
+        
         log.debug(`Users backup file id: ${userBackupId}`);
+
+        
+        log.info(`Saving removed roles summary`);
+        const removedRolesSummary = await this.getRemovedRolesSummary(responseRoles.userProcessed);
+        log.info(`Removed roles summary: ${removedRolesSummary}`);
+        const userInvalidRolesSummaryId = await UserMonitoringFileResourceUtils.saveFileResource(
+            removedRolesSummary,
+            filenameUUserRolesSummary,
+            this.api
+        );
+        
+        log.debug(`Users removed User Roles file id: ${userInvalidRolesSummaryId}`);
 
         const response = await this.pushReportToDhis(
             responseGroups.invalidUsersCount.toString(),
@@ -82,6 +96,7 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             responseRoles.response,
             userFixedId,
             userBackupId,
+            userInvalidRolesSummaryId,
             this.api,
             program
         );
@@ -108,6 +123,18 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             userActionRequired,
             `${csvErrorFilename}`
         );
+    }
+    
+    private async getRemovedRolesSummary(users: UserMonitoringUserResponse[]): Async<string> {
+        const formattedForbiddenUserRoles = users.reduce<Record<string, string[]>>((acc, item) => {
+            const invalidRoles = item.invalidUserRoles.map((r) => r.name).sort((a, b) => a.localeCompare(b));
+            if (invalidRoles.length > 0) {
+                acc[item.user.username] = invalidRoles;
+            }
+            return acc;
+        }, {});
+
+        return JSON.stringify(formattedForbiddenUserRoles, null, 2);
     }
 
     private async pushEmptyReportToDhis(
@@ -177,6 +204,7 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
         status: string,
         userFixedFileResourceId: string,
         userBackupFileResourceid: string,
+        userInvalidRolesFileResourceid: string,
         api: D2Api,
         program: UserMonitoringProgramMetadata
     ) {
@@ -210,6 +238,8 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
                         return { dataElement: item.id, value: userFixedFileResourceId };
                     case dataelement_file_valid_users_file_code:
                         return { dataElement: item.id, value: userBackupFileResourceid };
+                    case dataelement_file_invalid_user_roles_file_code:
+                        return { dataElement: item.id, value: userInvalidRolesFileResourceid };
                     case dataelement_users_pushed_code:
                         return { dataElement: item.id, value: status };
                     default:

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -54,7 +54,8 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
     async save(
         program: UserMonitoringProgramMetadata,
         responseGroups: PermissionFixerReport,
-        responseRoles: PermissionFixerExtendedReport
+        responseRoles: PermissionFixerExtendedReport,
+        rolesSummary: string
     ): Async<string> {
         log.info(`Saving report `);
 
@@ -78,10 +79,8 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
 
         
         log.info(`Saving removed roles summary`);
-        const removedRolesSummary = await this.getRemovedRolesSummary(responseRoles.userProcessed);
-        log.info(`Removed roles summary: ${removedRolesSummary}`);
         const userInvalidRolesSummaryId = await UserMonitoringFileResourceUtils.saveFileResource(
-            removedRolesSummary,
+            rolesSummary,
             filenameUUserRolesSummary,
             this.api
         );
@@ -123,18 +122,6 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             userActionRequired,
             `${csvErrorFilename}`
         );
-    }
-    
-    private async getRemovedRolesSummary(users: UserMonitoringUserResponse[]): Async<string> {
-        const formattedForbiddenUserRoles = users.reduce<Record<string, string[]>>((acc, item) => {
-            const invalidRoles = item.invalidUserRoles.map((r) => r.name).sort((a, b) => a.localeCompare(b));
-            if (invalidRoles.length > 0) {
-                acc[item.user.username] = invalidRoles;
-            }
-            return acc;
-        }, {});
-
-        return JSON.stringify(formattedForbiddenUserRoles, null, 2);
     }
 
     private async pushEmptyReportToDhis(

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerReportD2Repository.ts
@@ -34,15 +34,10 @@ type ServerResponse = { status: string; typeReports: object[] };
 export class PermissionFixerReportD2Repository implements PermissionFixerReportRepository {
     constructor(private api: D2Api) {}
 
-    async saveEmptyReport(
-        program: UserMonitoringProgramMetadata
-    ): Async<string> {
+    async saveEmptyReport(program: UserMonitoringProgramMetadata): Async<string> {
         log.info(`Saving report `);
 
-        const response = await this.pushEmptyReportToDhis(
-            this.api,
-            program
-        );
+        const response = await this.pushEmptyReportToDhis(this.api, program);
 
         if (response?.status != "OK") {
             throw new Error("Error on push report: " + JSON.stringify(response));
@@ -74,17 +69,16 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
             filenameUserBackup,
             this.api
         );
-        
+
         log.debug(`Users backup file id: ${userBackupId}`);
 
-        
         log.info(`Saving removed roles summary`);
         const userInvalidRolesSummaryId = await UserMonitoringFileResourceUtils.saveFileResource(
             rolesSummary,
             filenameUUserRolesSummary,
             this.api
         );
-        
+
         log.debug(`Users removed User Roles file id: ${userInvalidRolesSummaryId}`);
 
         const response = await this.pushReportToDhis(
@@ -124,9 +118,7 @@ export class PermissionFixerReportD2Repository implements PermissionFixerReportR
         );
     }
 
-    private async pushEmptyReportToDhis(
-        api: D2Api,
-        program: UserMonitoringProgramMetadata) {
+    private async pushEmptyReportToDhis(api: D2Api, program: UserMonitoringProgramMetadata) {
         log.info(`Create and Pushing report to DHIS2`);
         const dataValues: UserMonitoringReportValues[] = program.dataElements
             .map(item => {

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
@@ -23,6 +23,7 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
         const { templates: templateGroups, excludedRoles: excludedRoles } = options;
 
         const userRoles: PermissionFixerUserRoleAuthority[] = await this.getAllUserRoles(options);
+        log.info(`Get metadata: ${JSON.stringify(userRoles)}`);
         log.info("Validating roles...");
         const isAuthValid = this.validateAuths(userRoles, excludedRoles);
         if (!isAuthValid) {
@@ -38,8 +39,9 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
     private async getAllUserRoles(
         options: PermissionFixerMetadataConfig
     ): Async<PermissionFixerUserRoleAuthority[]> {
-        log.info(`Get metadata: All roles excluding ids: ${JSON.stringify(options.excludedRoles.join(", "))}`);
         const excludeRoles = options.excludedRoles;
+        const excludeRoleIds = excludeRoles.map(role => role.id);
+        log.info(`Get metadata: All roles excluding ids: ${excludeRoleIds.join(", ")}`);
         if (excludeRoles.length == 0) {
             const responses = await this.api
                 .get<UserRoleAuthorities>(`/userRoles.json?paging=false&fields=id,name,authorities`)
@@ -49,7 +51,7 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
         } else {
             const responses = await this.api
                 .get<UserRoleAuthorities>(
-                    `/userRoles.json?paging=false&fields=id,name,authorities&filter=id:!in:[${excludeRoles.join(
+                    `/userRoles.json?paging=false&fields=id,name,authorities&filter=id:!in:[${excludeRoleIds.join(
                         ","
                     )}]`
                 )

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
@@ -23,7 +23,6 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
         const { templates: templateGroups, excludedRoles: excludedRoles } = options;
 
         const userRoles: PermissionFixerUserRoleAuthority[] = await this.getAllUserRoles(options);
-        log.info(`Get metadata: ${JSON.stringify(userRoles)}`);
         log.info("Validating roles...");
         const isAuthValid = this.validateAuths(userRoles, excludedRoles);
         if (!isAuthValid) {

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
@@ -38,7 +38,7 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
     private async getAllUserRoles(
         options: PermissionFixerMetadataConfig
     ): Async<PermissionFixerUserRoleAuthority[]> {
-        log.info(`Get metadata: All roles excluding ids: ${options.excludedRoles.join(", ")}`);
+        log.info(`Get metadata: All roles excluding ids: ${JSON.stringify(options.excludedRoles.join(", "))}`);
         const excludeRoles = options.excludedRoles;
         if (excludeRoles.length == 0) {
             const responses = await this.api

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserD2Repository.ts
@@ -15,7 +15,7 @@ export class PermissionFixerUserD2Repository implements PermissionFixerUserRepos
         //todo use d2api filters
         const responses = await this.api
             .get<Users>(
-                `/users.json?paging=false&fields=*,userCredentials[*]&filter=id:in:[${ids.join(",")}]`
+                `/users.json?paging=false&fields=*,userRoles[id,name],userCredentials[*,userRoles[id,name]]&filter=id:in:[${ids.join(",")}]`
             )
             .getData();
 
@@ -26,7 +26,7 @@ export class PermissionFixerUserD2Repository implements PermissionFixerUserRepos
         log.info(`Get metadata: All users`);
         //todo use d2api filters
         const responses = await this.api
-            .get<Users>(`/users.json?paging=false&fields=*,userCredentials[*]`)
+            .get<Users>(`/users.json?paging=false&fields=*,userCredentials[*,userRoles[id,name]],userRoles[id,name]`)
             .getData();
 
         return responses["users"];

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserD2Repository.ts
@@ -15,7 +15,9 @@ export class PermissionFixerUserD2Repository implements PermissionFixerUserRepos
         //todo use d2api filters
         const responses = await this.api
             .get<Users>(
-                `/users.json?paging=false&fields=*,userRoles[id,name],userCredentials[*,userRoles[id,name]]&filter=id:in:[${ids.join(",")}]`
+                `/users.json?paging=false&fields=*,userRoles[id,name],userCredentials[*,userRoles[id,name]]&filter=id:in:[${ids.join(
+                    ","
+                )}]`
             )
             .getData();
 
@@ -26,7 +28,9 @@ export class PermissionFixerUserD2Repository implements PermissionFixerUserRepos
         log.info(`Get metadata: All users`);
         //todo use d2api filters
         const responses = await this.api
-            .get<Users>(`/users.json?paging=false&fields=*,userCredentials[*,userRoles[id,name]],userRoles[id,name]`)
+            .get<Users>(
+                `/users.json?paging=false&fields=*,userCredentials[*,userRoles[id,name]],userRoles[id,name]`
+            )
             .getData();
 
         return responses["users"];

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -28,17 +28,27 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
     }
     async save(userGroup: PermissionFixerUserGroupExtended, _users: Ref[]): Async<string> {
         try {
-            const response = await this.api.models.userGroups.put(userGroup).getData();
-            if (_(response.errorReports).isEmpty()) {
-                log.info("Users added to minimal group");
-            } else {
-                log.error("Error adding users to minimal group");
-            }
+            const patchOps = _users.map((userId) => ({
+                op: "add",
+                path: "/users/-",
+                value: { id: userId.id },
+            })); 
+
+            const response = await this.api.request<string>({
+                method: "patch",
+                url: `/41/userGroups/${userGroup.id}`,
+                headers: {
+                    "Content-Type": "application/json-patch+json"
+                },
+                data: patchOps,
+            }).getData();
+
+            log.info(`Users [${_users.join(", ")}] added to group ${userGroup.name} (${userGroup.id})`);
 
             log.info(JSON.stringify(response));
-
             return "SUCCESS";
         } catch (error) {
+            log.error("Error adding users to group");
             console.debug(error);
             return "ERROR";
         }

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -7,6 +7,7 @@ import { Async } from "domain/entities/Async";
 import { UserGroupNotFoundException } from "./exception/UserGroupNotFoundException";
 import { Ref } from "domain/entities/Base";
 import { Stats } from "domain/entities/Stats";
+import { Method } from "@eyeseetea/d2-api/repositories/HttpClientRepository";
 
 export class PermissionFixerUserGroupD2Repository implements PermissionFixerUserGroupRepository {
     constructor(private api: D2Api) {}
@@ -35,7 +36,7 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
             })); 
 
             const response = await this.api.request<string>({
-                method: "patch",
+                method: "patch" as Method,
                 url: `/41/userGroups/${userGroup.id}`,
                 headers: {
                     "Content-Type": "application/json-patch+json"

--- a/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerUserGroupD2Repository.ts
@@ -29,20 +29,22 @@ export class PermissionFixerUserGroupD2Repository implements PermissionFixerUser
     }
     async save(userGroup: PermissionFixerUserGroupExtended, _users: Ref[]): Async<string> {
         try {
-            const patchOps = _users.map((userId) => ({
+            const patchOps = _users.map(userId => ({
                 op: "add",
                 path: "/users/-",
                 value: { id: userId.id },
-            })); 
+            }));
 
-            const response = await this.api.request<string>({
-                method: "patch" as Method,
-                url: `/41/userGroups/${userGroup.id}`,
-                headers: {
-                    "Content-Type": "application/json-patch+json"
-                },
-                data: patchOps,
-            }).getData();
+            const response = await this.api
+                .request<string>({
+                    method: "patch" as Method,
+                    url: `/41/userGroups/${userGroup.id}`,
+                    headers: {
+                        "Content-Type": "application/json-patch+json",
+                    },
+                    data: patchOps,
+                })
+                .getData();
 
             log.info(`Users [${_users.join(", ")}] added to group ${userGroup.name} (${userGroup.id})`);
 

--- a/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
+++ b/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
@@ -11,4 +11,7 @@ export interface PermissionFixerReportRepository {
         responseGroups: PermissionFixerReport,
         responseRoles: PermissionFixerExtendedReport
     ): Async<string>;
+    saveEmptyReport(
+        program: UserMonitoringProgramMetadata
+    ): Async<string>;
 }

--- a/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
+++ b/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
@@ -12,7 +12,5 @@ export interface PermissionFixerReportRepository {
         responseRoles: PermissionFixerExtendedReport,
         rolesSummary: string
     ): Async<string>;
-    saveEmptyReport(
-        program: UserMonitoringProgramMetadata
-    ): Async<string>;
+    saveEmptyReport(program: UserMonitoringProgramMetadata): Async<string>;
 }

--- a/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
+++ b/src/domain/repositories/user-monitoring/permission-fixer/PermissionFixerReportRepository.ts
@@ -9,7 +9,8 @@ export interface PermissionFixerReportRepository {
     save(
         program: UserMonitoringProgramMetadata,
         responseGroups: PermissionFixerReport,
-        responseRoles: PermissionFixerExtendedReport
+        responseRoles: PermissionFixerExtendedReport,
+        rolesSummary: string
     ): Async<string>;
     saveEmptyReport(
         program: UserMonitoringProgramMetadata

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -119,7 +119,7 @@ export class RunUserPermissionUseCase {
             (finalUserGroup.invalidUsersCount > 0 || finalUserRoles.invalidUsersCount > 0)
         ) {
             log.info(`Sending user-monitoring user-permissions report results`);
-
+            
             const response = await this.reportRepository.save(
                 programMetadata,
                 finalUserGroup,
@@ -336,25 +336,22 @@ export class RunUserPermissionUseCase {
                         allExceptionsToBeIgnoredByUser,
                         allExceptionsToBeIgnoredByGroup
                     );
-                    //the invalid roles are the ones that are not in the valid roles
+                    // the invalid roles are the ones that are not in the valid roles
                     const allInvalidRolesSingleListFixed = allInValidRolesSingleList?.filter(item => {
-                        return allValidRolesSingleListWithExceptions.indexOf(item) == -1;
+                        return !allValidRolesSingleListWithExceptions.includes(item);
                     });
-                    //fill the valid roles in the user  against all the possible valid roles
+
+                    // fill the valid roles in the user against all the possible valid roles
                     const userValidRoles = user.userCredentials.userRoles.filter(userRole => {
-                        return (
-                            JSON.stringify(allValidRolesSingleListWithExceptions).indexOf(userRole.id) >= 0
-                        );
+                        return allValidRolesSingleListWithExceptions.includes(userRole.id);
                     });
-
-                    //fill the invalid roles in the user against all the possible invalid roles
                     const userInvalidRoles = user.userCredentials.userRoles.filter(userRole => {
-                        return (
-                            JSON.stringify(allValidRolesSingleListWithExceptions).indexOf(userRole.id) ==
-                                -1 && JSON.stringify(allInvalidRolesSingleListFixed).indexOf(userRole.id) >= 0
-                        );
+                        const id = userRole.id;
+                        const isValid = allValidRolesSingleListWithExceptions.some(role => role === id);
+                        const isInvalid = allInvalidRolesSingleListFixed.some(role => role === id);
+                        return !isValid && isInvalid;
                     });
-
+                    
                     //clone user
                     const fixedUser = JSON.parse(JSON.stringify(user));
                     fixedUser.userCredentials.userRoles = userValidRoles;

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -120,10 +120,14 @@ export class RunUserPermissionUseCase {
         ) {
             log.info(`Sending user-monitoring user-permissions report results`);
             
+            const removedRolesSummary = await this.getRemovedRolesSummary(finalUserRoles.userProcessed);
+            log.info(`Removed roles summary: ${removedRolesSummary}`);
+
             const response = await this.reportRepository.save(
                 programMetadata,
                 finalUserGroup,
-                finalUserRoles
+                finalUserRoles,
+                removedRolesSummary
             );
 
             return {
@@ -148,6 +152,18 @@ export class RunUserPermissionUseCase {
                 rolesReport: undefined,
             };
         }
+    }
+
+    private async getRemovedRolesSummary(users: UserMonitoringUserResponse[]): Async<string> {
+        const formattedForbiddenUserRoles = users.reduce<Record<string, string[]>>((acc, item) => {
+            const invalidRoles = item.invalidUserRoles.map((r) => r.name).sort((a, b) => a.localeCompare(b));
+            if (invalidRoles.length > 0) {
+                acc[item.user.username] = invalidRoles;
+            }
+            return acc;
+        }, {});
+
+        return JSON.stringify(formattedForbiddenUserRoles, null, 2);
     }
 
     private preProcessUsers(

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -67,7 +67,6 @@ export class RunUserPermissionUseCase {
         const allUserTemplatesId = allUserTemplates.map(templateUser => templateUser.id);
 
         const usersToProcessGroups = allUser.filter(user => {
-            log.info(user.username);
             return (
                 excludedUsersId.includes(user.id) === false && allUserTemplatesId.includes(user.id) === false
             );
@@ -84,12 +83,12 @@ export class RunUserPermissionUseCase {
             templatesWithAuthorities,
             usersToProcessGroups
         );
-
+        log.info(`UserGroups processed. Affected user count: ${responseUserGroups.invalidUsersCount}`);
+        log.info(`UserGroups processed. Affected users: ${JSON.stringify(responseUserGroups.listOfAffectedUsers)}`);
         log.info(`Run user Role monitoring`);
         const allUserAfterProccessGroups = await this.userRepository.getAllUsers();
 
         const usersToProcessRoles = allUserAfterProccessGroups.filter(user => {
-            log.info(JSON.stringify(allUserTemplatesId));
             return (
                 excludedUsersId.includes(user.id) === false && allUserTemplatesId.includes(user.id) === false
             );

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -84,7 +84,9 @@ export class RunUserPermissionUseCase {
             usersToProcessGroups
         );
         log.info(`UserGroups processed. Affected user count: ${responseUserGroups.invalidUsersCount}`);
-        log.info(`UserGroups processed. Affected users: ${JSON.stringify(responseUserGroups.listOfAffectedUsers)}`);
+        log.info(
+            `UserGroups processed. Affected users: ${JSON.stringify(responseUserGroups.listOfAffectedUsers)}`
+        );
         log.info(`Run user Role monitoring`);
         const allUserAfterProccessGroups = await this.userRepository.getAllUsers();
 
@@ -119,7 +121,7 @@ export class RunUserPermissionUseCase {
             (finalUserGroup.invalidUsersCount > 0 || finalUserRoles.invalidUsersCount > 0)
         ) {
             log.info(`Sending user-monitoring user-permissions report results`);
-            
+
             const removedRolesSummary = await this.getRemovedRolesSummary(finalUserRoles.userProcessed);
             log.info(`Removed roles summary: ${removedRolesSummary}`);
 
@@ -156,7 +158,7 @@ export class RunUserPermissionUseCase {
 
     private async getRemovedRolesSummary(users: UserMonitoringUserResponse[]): Async<string> {
         const formattedForbiddenUserRoles = users.reduce<Record<string, string[]>>((acc, item) => {
-            const invalidRoles = item.invalidUserRoles.map((r) => r.name).sort((a, b) => a.localeCompare(b));
+            const invalidRoles = item.invalidUserRoles.map(r => r.name).sort((a, b) => a.localeCompare(b));
             if (invalidRoles.length > 0) {
                 acc[item.user.username] = invalidRoles;
             }
@@ -367,7 +369,7 @@ export class RunUserPermissionUseCase {
                         const isInvalid = allInvalidRolesSingleListFixed.some(role => role === id);
                         return !isValid && isInvalid;
                     });
-                    
+
                     //clone user
                     const fixedUser = JSON.parse(JSON.stringify(user));
                     fixedUser.userCredentials.userRoles = userValidRoles;

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -136,9 +136,10 @@ export class RunUserPermissionUseCase {
                 rolesReport: finalUserRoles,
             };
         } else {
-            log.info(`Nothing to report. No invalid users found.`);
+            log.info(`No invalid users found.`);
+            const response = await this.reportRepository.saveEmptyReport(programMetadata);
             return {
-                message: "Nothing to report. No invalid users found.",
+                message: response,
                 allUsersToProcessGroups: usersToProcessGroups,
                 allUsersToProcessRoles: usersToProcessRoles,
                 excludedUsers: excludedUsers,

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
@@ -45,7 +45,7 @@ describe("RunUserPermissionUseCase", () => {
         expect(result.excludedUsers[0]).toEqual(clonedValidUser);
         expect(result.groupsReport).toEqual(undefined);
         expect(result.rolesReport).toEqual(undefined);
-        expect(result.message).toEqual("Nothing to report. No invalid users found.");
+        expect(result.message).toEqual("No invalid users found.");
     });
 
     it("Should ignore user if the user has valid roles", async () => {
@@ -60,7 +60,7 @@ describe("RunUserPermissionUseCase", () => {
         expect(result.userTemplates).toEqual([]);
         expect(result.groupsReport).toEqual(undefined);
         expect(result.rolesReport).toEqual(undefined);
-        expect(result.message).toEqual("Nothing to report. No invalid users found.");
+        expect(result.message).toEqual("No invalid users found.");
     });
 
     it("Should fix user if the user has invalid authorities", async () => {
@@ -208,7 +208,8 @@ function givenConfigRepository(config: PermissionFixerMetadataConfig) {
 
 function givenReportRepository(result: string) {
     const mockedRepository = mock(PermissionFixerReportD2Repository);
-    when(mockedRepository.save(anything(), anything(), anything())).thenReturn(Promise.resolve(result));
+    when(mockedRepository.save(anything(),anything(),anything())).thenReturn(Promise.resolve(result));
+    when(mockedRepository.saveEmptyReport(anything())).thenReturn(Promise.resolve("No invalid users found."));
     const reportRepository = instance(mockedRepository);
     return reportRepository;
 }

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
@@ -208,7 +208,7 @@ function givenConfigRepository(config: PermissionFixerMetadataConfig) {
 
 function givenReportRepository(result: string) {
     const mockedRepository = mock(PermissionFixerReportD2Repository);
-    when(mockedRepository.save(anything(),anything(),anything())).thenReturn(Promise.resolve(result));
+    when(mockedRepository.save(anything(),anything(),anything(),anything())).thenReturn(Promise.resolve(result));
     when(mockedRepository.saveEmptyReport(anything())).thenReturn(Promise.resolve("No invalid users found."));
     const reportRepository = instance(mockedRepository);
     return reportRepository;

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
@@ -208,7 +208,9 @@ function givenConfigRepository(config: PermissionFixerMetadataConfig) {
 
 function givenReportRepository(result: string) {
     const mockedRepository = mock(PermissionFixerReportD2Repository);
-    when(mockedRepository.save(anything(),anything(),anything(),anything())).thenReturn(Promise.resolve(result));
+    when(mockedRepository.save(anything(), anything(), anything(), anything())).thenReturn(
+        Promise.resolve(result)
+    );
     when(mockedRepository.saveEmptyReport(anything())).thenReturn(Promise.resolve("No invalid users found."));
     const reportRepository = instance(mockedRepository);
     return reportRepository;


### PR DESCRIPTION
Required:
https://github.com/EyeSeeTea/d2-api/pull/171

This branch starts in: 
https://github.com/EyeSeeTea/d2-tools/pull/86

This PR includes several important fixes and improvements to the user monitoring logic:

Fixes the issue of sending empty reports: Reports containing only [] (length ≤ 2) are now correctly ignored and not sent.

Changes the way user groups are updated: Now follows the same logic as the user app, avoiding the unintended bug overwrite of sharing settings that was happening with the previous method.

Adds the ability to send explicit empty reports: This helps distinguish between "no invalid users found" and "script did not run" — if no report exists in DHIS2, it means the monitoring did not execute.

Improves some log messages for clarity and consistency.

These updates ensure more accurate reporting, preserve sharing configurations, and improve overall traceability of script execution.