### PR TITLE
Feature/fix 242 user monitoring

### DIFF
--- a/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
+++ b/src/data/user-monitoring/permission-fixer/PermissionFixerTemplateD2Repository.ts
@@ -71,7 +71,7 @@ export class PermissionFixerTemplateD2Repository implements PermissionFixerTempl
                 return template.id == item.template.id;
             });
             const templateAutorities = _.compact(
-                user?.userCredentials.userRoles.flatMap(role => {
+                user?.userRoles.flatMap(role => {
                     const userRoleAuthorities = userRoles.filter(userRoleitem => {
                         return userRoleitem.id == role.id;
                     });

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -303,7 +303,7 @@ export class RunUserPermissionUseCase {
 
                 if (user.userRoles === undefined) {
                     const fixedUser = JSON.parse(JSON.stringify(user));
-                    this.setUserRoles(fixedUser, [{ id: minimalRole.id, name: "Minimal Role"}]);
+                    this.setUserRoles(fixedUser, [{ id: minimalRole.id, name: "Minimal Role" }]);
                     const userInfoRes: UserMonitoringUserResponse = {
                         user: user,
                         fixedUser: fixedUser,
@@ -378,8 +378,12 @@ export class RunUserPermissionUseCase {
 
                     //clone user
                     const fixedUser = JSON.parse(JSON.stringify(user));
-                    this.setUserRoles(fixedUser, userValidRoles.map(role => {
-                        return { id: role.id, name: role.name };}));
+                    this.setUserRoles(
+                        fixedUser,
+                        userValidRoles.map(role => {
+                            return { id: role.id, name: role.name };
+                        })
+                    );
                     const userTemplateGroupMatch = templateGroupMatch ?? undefined;
                     if (userTemplateGroupMatch == undefined) {
                         throw new UserTemplateNotFoundException(

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -269,26 +269,11 @@ export class RunUserPermissionUseCase {
             };
         }
     }
-    
-    
-    private getUserRoles(user: PermissionFixerUser): NamedRef[] {
-        if ("userCredentials" in user && user.userCredentials?.userRoles) {
-            return user.userCredentials.userRoles;
-        } else if ("userRoles" in user && user.userRoles) {
-            return user.userRoles;
-        }
-        return [];
-    }
 
     private setUserRoles(user: PermissionFixerUser, roles: NamedRef[]) {
         user.userRoles = roles;
         if ("userCredentials" in user) {
-            if (!user.userCredentials) {
-                user.userRoles = roles; 
-            } else {
-                user.userCredentials.userRoles = roles;
-                user.userRoles = roles; 
-            }
+            user.userCredentials.userRoles = roles;
         }
     }
 
@@ -314,7 +299,7 @@ export class RunUserPermissionUseCase {
                     );
                 });
 
-                if (this.getUserRoles(user) === undefined) {
+                if (user.userRoles === undefined) {
                     const fixedUser = JSON.parse(JSON.stringify(user));
                     this.setUserRoles(fixedUser, [{ id: minimalRole.id, name: "Minimal Role"}]);
 
@@ -382,10 +367,10 @@ export class RunUserPermissionUseCase {
                     });
 
                     // fill the valid roles in the user against all the possible valid roles
-                    const userValidRoles = user.userCredentials.userRoles.filter(userRole => {
+                    const userValidRoles = user.userRoles.filter(userRole => {
                         return allValidRolesSingleListWithExceptions.includes(userRole.id);
                     });
-                    const userInvalidRoles = user.userCredentials.userRoles.filter(userRole => {
+                    const userInvalidRoles = user.userRoles.filter(userRole => {
                         const id = userRole.id;
                         const isValid = allValidRolesSingleListWithExceptions.some(role => role === id);
                         const isInvalid = allInvalidRolesSingleListFixed.some(role => role === id);

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -253,6 +253,28 @@ export class RunUserPermissionUseCase {
             };
         }
     }
+    
+    
+    private getUserRoles(user: PermissionFixerUser): NamedRef[] {
+        if ("userCredentials" in user && user.userCredentials?.userRoles) {
+            return user.userCredentials.userRoles;
+        } else if ("userRoles" in user && user.userRoles) {
+            return user.userRoles;
+        }
+        return [];
+    }
+
+    private setUserRoles(user: PermissionFixerUser, roles: NamedRef[]) {
+        user.userRoles = roles;
+        if ("userCredentials" in user) {
+            if (!user.userCredentials) {
+                user.userRoles = roles; 
+            } else {
+                user.userCredentials.userRoles = roles;
+                user.userRoles = roles; 
+            }
+        }
+    }
 
     private processUsers(
         allUsers: PermissionFixerUser[],
@@ -276,10 +298,12 @@ export class RunUserPermissionUseCase {
                     );
                 });
 
-                if (user.userCredentials.userRoles === undefined) {
+                if (this.getUserRoles(user) === undefined) {
                     const fixedUser = JSON.parse(JSON.stringify(user));
-                    fixedUser.userCredentials.userRoles = [{ id: minimalRole.id }];
-                    fixedUser.userRoles = [{ id: minimalRole.id }];
+                    this.setUserRoles(fixedUser, [{ id: minimalRole.id, name: "Minimal Role"}]);
+
+                    //fixedUser.userCredentials.userRoles = [{ id: minimalRole.id }];
+                    //fixedUser.userRoles = [{ id: minimalRole.id }];
                     const userInfoRes: UserMonitoringUserResponse = {
                         user: user,
                         fixedUser: fixedUser,
@@ -341,14 +365,14 @@ export class RunUserPermissionUseCase {
                         return allValidRolesSingleListWithExceptions.indexOf(item) == -1;
                     });
                     //fill the valid roles in the user  against all the possible valid roles
-                    const userValidRoles = user.userCredentials.userRoles.filter(userRole => {
+                    const userValidRoles = this.getUserRoles(user).filter(userRole => {
                         return (
                             JSON.stringify(allValidRolesSingleListWithExceptions).indexOf(userRole.id) >= 0
                         );
                     });
 
                     //fill the invalid roles in the user against all the possible invalid roles
-                    const userInvalidRoles = user.userCredentials.userRoles.filter(userRole => {
+                    const userInvalidRoles = this.getUserRoles(user).filter(userRole => {
                         return (
                             JSON.stringify(allValidRolesSingleListWithExceptions).indexOf(userRole.id) ==
                                 -1 && JSON.stringify(allInvalidRolesSingleListFixed).indexOf(userRole.id) >= 0
@@ -357,8 +381,8 @@ export class RunUserPermissionUseCase {
 
                     //clone user
                     const fixedUser = JSON.parse(JSON.stringify(user));
-                    fixedUser.userCredentials.userRoles = userValidRoles;
-                    fixedUser.userRoles = userValidRoles;
+                    this.setUserRoles(fixedUser, userValidRoles.map(role => {
+                        return { id: role.id, name: "" };}));
                     const userTemplateGroupMatch = templateGroupMatch ?? undefined;
                     if (userTemplateGroupMatch == undefined) {
                         throw new UserTemplateNotFoundException(

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -380,7 +380,7 @@ export class RunUserPermissionUseCase {
                     //clone user
                     const fixedUser = JSON.parse(JSON.stringify(user));
                     this.setUserRoles(fixedUser, userValidRoles.map(role => {
-                        return { id: role.id, name: "" };}));
+                        return { id: role.id, name: role.name };}));
                     const userTemplateGroupMatch = templateGroupMatch ?? undefined;
                     if (userTemplateGroupMatch == undefined) {
                         throw new UserTemplateNotFoundException(

--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -302,9 +302,6 @@ export class RunUserPermissionUseCase {
                 if (user.userRoles === undefined) {
                     const fixedUser = JSON.parse(JSON.stringify(user));
                     this.setUserRoles(fixedUser, [{ id: minimalRole.id, name: "Minimal Role"}]);
-
-                    //fixedUser.userCredentials.userRoles = [{ id: minimalRole.id }];
-                    //fixedUser.userRoles = [{ id: minimalRole.id }];
                     const userInfoRes: UserMonitoringUserResponse = {
                         user: user,
                         fixedUser: fixedUser,


### PR DESCRIPTION
This script was originally developed for 2.36-2.38, but API changes in 2.41 and now in 2.42 required adjustments.
This PR updates user role handling to use the root user object, which is the recommended approach in 2.42 (and also a good option in 2.41 due is a copy of the userRoles in userCredentials), since user.userCredentials is being removed due to duplicated parameters. 

I’ve kept user.userCredentials.userRoles as a temporary fallback for 2.41 compatibility (especially for pushing users and generating backup files), but it can be removed in the future once we move fully to 2.42.

This branch is already running in our servers (and we could considered funtional testing done).
I think we should do a update of all the instances when all this PR was merged.