### PR TITLE
Preserve excluded user roles during permission fixes

### DIFF
--- a/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/RunUserPermissionUseCase.ts
@@ -217,6 +217,7 @@ export class RunUserPermissionUseCase {
             excludedRolesByRole,
             excludedRolesByUser,
             excludedRolesByGroup,
+            excludedRoles,
         } = options;
 
         log.info("Preprocess " + allUsers.length + " users...");
@@ -234,6 +235,7 @@ export class RunUserPermissionUseCase {
             excludedRolesByRole,
             excludedRolesByGroup,
             excludedRolesByUser,
+            excludedRoles,
             minimalRole
         );
 
@@ -300,6 +302,7 @@ export class RunUserPermissionUseCase {
         excludedRolesByRole: RolesByRoles[],
         excludedRolesByGroup: RolesByGroup[],
         excludedRolesByUser: RolesByUser[],
+        excludedRoles: NamedRef[],
         minimalRole: Ref
     ): UserMonitoringUserResponse[] {
         log.info("Processing " + allUsers.length + " users...");
@@ -369,11 +372,13 @@ export class RunUserPermissionUseCase {
                             if (item.active_role.id in user.userRoles) return item.ignore_role.id;
                         })
                     );
+                    const allExcludedRoles = excludedRoles.map(role => role.id);
                     const allValidRolesSingleListWithExceptions = _.concat(
                         allValidRolesSingleList,
                         allExceptionsToBeIgnoredByRole,
                         allExceptionsToBeIgnoredByUser,
-                        allExceptionsToBeIgnoredByGroup
+                        allExceptionsToBeIgnoredByGroup,
+                        allExcludedRoles
                     );
                     // the invalid roles are the ones that are not in the valid roles
                     const allInvalidRolesSingleListFixed = allInValidRolesSingleList?.filter(item => {

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
@@ -3,6 +3,7 @@ import {
     PermissionFixerConfig,
     PermissionFixerMetadataConfig,
 } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerConfigOptions";
+import { NamedRef } from "domain/entities/Base";
 import {
     PermissionFixerTemplateGroup,
     PermissionFixerTemplateGroupExtended,
@@ -167,6 +168,29 @@ export const fakeInvalidUser: PermissionFixerUser = {
     selftRefistered: false,
     phoneNumber: "",
     passwordLastUpdated: "",
+};
+
+export const excludedRoles: NamedRef[] = [
+    {
+        id: "y3rLgUxlsYH",
+        name: "METADATSYNC - CONF",
+    },
+    {
+        id: "OWzgCaHxaLe",
+        name: "METADATASYNC - EXECUTOR",
+    },
+];
+
+export const fakeInvalidUserWithExcludedRoles: PermissionFixerUser = {
+    ...fakeInvalidUser,
+    userCredentials: {
+        ...fakeInvalidUser.userCredentials!,
+        userRoles: [
+            ...fakeInvalidUser.userCredentials!.userRoles,
+            ...excludedRoles,
+        ],
+    },
+    userRoles: [...fakeInvalidUser.userRoles!, ...excludedRoles],
 };
 
 export const fakeUserWithoutUserGroup: PermissionFixerUser = {

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionUseCase.specs.ts
@@ -3,8 +3,10 @@ import { RunUserPermissionUseCase } from "../RunUserPermissionUseCase";
 import {
     baseMetadataConfig,
     fakeInvalidUser,
+    fakeInvalidUserWithExcludedRoles,
     fakeUserWithoutUserGroup,
     fakeValidUser,
+    excludedRoles,
     permissionFixerTemplateGroupsExtended,
     programMetadata,
 } from "./RunUserPermissionTest.data";
@@ -28,7 +30,9 @@ let basicConfig: PermissionFixerMetadataConfig;
 let clonedFakeUserWithoutGroup: PermissionFixerUser;
 let clonedValidUser: PermissionFixerUser;
 let clonedInvalidUser: PermissionFixerUser;
+let clonedInvalidUserWithExcludedRoles: PermissionFixerUser;
 let configWithWrongMinimalGroup: PermissionFixerMetadataConfig;
+let configWithGlobalExcludedRoles: PermissionFixerMetadataConfig;
 let clonedTemplateAuthorities: PermissionFixerTemplateGroupExtended[];
 let clonedInvalidTemplateAuthorities: PermissionFixerTemplateGroupExtended[];
 
@@ -90,6 +94,26 @@ describe("RunUserPermissionUseCase", () => {
                 id: "BQEME6bsUpZ",
                 name: "Dummy authority",
             },
+        ]);
+    });
+
+    it("Should keep globally excluded roles when fixing invalid roles", async () => {
+        const useCase = givenUseCaseCustomUsers(
+            givenUserRepository([clonedInvalidUserWithExcludedRoles]),
+            givenConfigRepository(configWithGlobalExcludedRoles),
+            givenTemplateRepository(clonedTemplateAuthorities)
+        );
+
+        const result = await useCase.execute();
+
+        expect(result.rolesReport?.usersBackup[0]?.userRoles).toEqual([
+            { id: "invalidRoleId", name: "Invalid dummy role" },
+            { id: "BQEME6bsUpZ", name: "Dummy authority" },
+            ...excludedRoles,
+        ]);
+        expect(result.rolesReport?.usersFixed[0]?.userRoles).toEqual([
+            { id: "BQEME6bsUpZ", name: "Dummy authority" },
+            ...excludedRoles,
         ]);
     });
 
@@ -164,6 +188,7 @@ beforeEach(() => {
     clonedFakeUserWithoutGroup = copyObject(fakeUserWithoutUserGroup);
     clonedValidUser = copyObject(fakeValidUser);
     clonedInvalidUser = copyObject(fakeInvalidUser);
+    clonedInvalidUserWithExcludedRoles = copyObject(fakeInvalidUserWithExcludedRoles);
     clonedFakeUserWithoutGroup = copyObject(fakeUserWithoutUserGroup);
     configWithWrongMinimalGroup = copyObject(baseMetadataConfig);
     configWithWrongMinimalGroup.minimalGroup = {
@@ -176,6 +201,8 @@ beforeEach(() => {
     configWithUserExcluded = copyObject(baseMetadataConfig);
     configWithUserExcluded.excludedUsers = [copyObject(fakeValidUser)];
     configThrowInvalidUsergroupException = copyObject(baseMetadataConfig);
+    configWithGlobalExcludedRoles = copyObject(baseMetadataConfig);
+    configWithGlobalExcludedRoles.excludedRoles = copyObject(excludedRoles);
     clonedTemplateAuthorities = copyObject(permissionFixerTemplateGroupsExtended);
     const permissionFixerInvalidTemplateGroupsExtended: PermissionFixerTemplateGroupExtended = copyObject(
         permissionFixerTemplateGroupsExtended[0]


### PR DESCRIPTION
# Summary
* ensure globally excluded user roles are kept when building fixed user payloads
* extend test data to include excluded role fixtures
# Testing
* yarn test-unit
* yarn start usermonitoring run-permissions-fixer --config-file  test-local-prod.json 

{
    "URL": {
        "username": "user",
        "password": "pass",
        "server": "http://url"
    },
    "WEBHOOK": {
    "ms_url": "https://empty",
    "server_name": "Dummy"
  }
}
