### PR TITLE
Regenerate categoryOptionCombos for categoryCombos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,12 +1103,12 @@ $ yarn start categoryOptionCombos translate \
 
 Regenerate categoryOptionCombos from `categoryCombo.categories[].categoryOptions[]` for all the `categoryCombos` on the server and delete obsolete categoryOptionCombos.
 
-By default both operations (create+update and delete) are being executed using the `VALIDATE` importMode (dry run). Use the --persist flag to apply changes (create+update) and --deleteCocs to confirm the deletion of obsolete categoryOptionCombos.
+By default both operations (create+update and delete) are being executed using the `VALIDATE` importMode (dry run). Use the --persist flag to apply changes (create+update) and --delete-cocs to confirm the deletion of obsolete categoryOptionCombos.
 
 ```shell
 yarn start categoryOptionCombos regenerate \
     --url=https://play.im.dhis2.org/dev \
     --auth="admin:district" \
     --persist \
-    --deleteCocs
+    --delete-cocs
 ```

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ yarn start usermonitoring run-2fa-reporter --config-file config.json
 #### Debug:
 
 ```shell
-$ LOG_LEVEL=debug yarn tsx --inspect-brk src/index.ts usermonitoring run-permissions-fixer --config-file config.json 
+$ LOG_LEVEL=debug yarn tsx --inspect-brk src/index.ts usermonitoring run-permissions-fixer --config-file config.json
 $ LOG_LEVEL=debug node --inspect-brk dist/index.js usermonitoring run-2fa-reporter   --config-file config.json
 ```
 
@@ -549,8 +549,6 @@ An exceptionGroup list containing groups whose users should be excluded from val
 
 An optional --disable-users CLI flag that, when passed, will disable users identified as invalid due to missing or disabled 2FA.
 
-
-
 The datastore must contain:
 
 ```json
@@ -564,18 +562,17 @@ The datastore must contain:
         "name": "Auth control group"
     },
     "whoAccountGroup": {
-    "id": "zjeqEiv9Ept",
-    "name": "WIDP Who Auth"
+        "id": "zjeqEiv9Ept",
+        "name": "WIDP Who Auth"
     },
     "exceptionGroup": [
-      {
-        "id": "HASUnoSNcSA",
-        "name": "user-scripts"
-      }
+        {
+            "id": "HASUnoSNcSA",
+            "name": "user-scripts"
+        }
     ]
 }
 ```
-
 
 #### run-users-monitoring Datastore:
 
@@ -1100,4 +1097,18 @@ $ yarn start categoryOptionCombos translate \
     --auth="admin:district" \
     --category-combo-ids=v1K6CE6bmtw
     --post
+```
+
+### Regenerate
+
+Regenerate categoryOptionCombos from `categoryCombo.categories[].categoryOptions[]` for all the `categoryCombos` on the server and delete obsolete categoryOptionCombos.
+
+By default both operations (create+update and delete) are being executed using the `VALIDATE` importMode (dry run). Use the --persist flag to apply changes (create+update) and --deleteCocs to confirm the deletion of obsolete categoryOptionCombos.
+
+```shell
+yarn start categoryOptionCombos regenerate \
+    --url=https://play.im.dhis2.org/dev \
+    --auth="admin:district" \
+    --persist \
+    --deleteCocs
 ```

--- a/src/data/CategoryComboD2Repository.ts
+++ b/src/data/CategoryComboD2Repository.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
-import { D2Api, Id } from "../../types/d2-api";
-import { CategoryComboRepository } from "./CategoryComboRepository";
+import { D2Api, Id } from "../types/d2-api";
+import { CategoryComboRepository } from "../domain/repositories/CategoryComboRepository";
 import { fixCategoryOptionOrder, mapCategoryOptionIdToCategoryIndex } from "data/utils/cocs";
 
 export class CategoryComboD2Repository implements CategoryComboRepository {
@@ -11,7 +11,7 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
         return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [] });
     }
 
-    async getAllByPages(options: {
+    private async getAllByPages(options: {
         page: number;
         pageSize: number;
         categoryCombos: CategoryCombo[];

--- a/src/data/CategoryOptionCombosD2Repository.ts
+++ b/src/data/CategoryOptionCombosD2Repository.ts
@@ -8,7 +8,7 @@ import {
 import { CategoryOptionCombo } from "domain/entities/CategoryOptionCombo";
 import { runMetadata } from "./dhis2-utils";
 import { Paginated } from "domain/entities/Pagination";
-import logger from "utils/log";
+import { fixCategoryOptionOrder, mapCategoryOptionIdToCategoryIndex } from "./utils/cocs";
 
 export class CategoryOptionCombosD2Repository implements CategoryOptionCombosRepository {
     constructor(private api: D2Api) {}
@@ -107,23 +107,7 @@ class D2CocOptionsOrderFixer {
         return cocs.map(coc => {
             const indexesByCategoryOptionId = this.getIndexesMapping(categoryCombosById, coc);
 
-            const categoryOptionsNotFound = _(coc.categoryOptions)
-                .filter(categoryOption => indexesByCategoryOptionId[categoryOption.id] === undefined)
-                .value();
-
-            if (!_.isEmpty(categoryOptionsNotFound)) {
-                // Return an empty array as categoryOptions to avoid unsafely relying on its order.
-                const coIds = categoryOptionsNotFound.map(getId).join(", ");
-                const msg = `[coc.id="${coc.id}"] Category options no longer in its categoryCombo: ${coIds}`;
-                logger.debug(msg);
-                return { ...coc, categoryOptions: [] };
-            } else {
-                const categoryOptionsSorted = _(coc.categoryOptions)
-                    .sortBy(categoryOption => indexesByCategoryOptionId[categoryOption.id] || 0)
-                    .value();
-
-                return { ...coc, categoryOptions: categoryOptionsSorted };
-            }
+            return fixCategoryOptionOrder(coc, indexesByCategoryOptionId);
         });
     }
 
@@ -134,14 +118,7 @@ class D2CocOptionsOrderFixer {
         const categoryCombo = categoryCombosById[coc.categoryCombo.id];
         if (!categoryCombo) throw new Error(`Category combo not found: ${coc.categoryCombo.id}`);
 
-        return _(categoryCombo.categories)
-            .flatMap((category, categoryIndex) => {
-                return category.categoryOptions.map(categoryOption => {
-                    return [categoryOption.id, categoryIndex] as [Id, number];
-                });
-            })
-            .fromPairs()
-            .value();
+        return mapCategoryOptionIdToCategoryIndex(categoryCombo);
     }
 
     private async getCategoryCombosByIdFromCocs(cocs: D2Coc[]): Promise<Record<Id, D2CategoryCombo>> {
@@ -168,7 +145,7 @@ class D2CocOptionsOrderFixer {
     }
 }
 
-type D2CategoryCombo = {
+export type D2CategoryCombo = {
     id: Id;
     categories: Array<{
         categoryOptions: { id: Id }[];

--- a/src/data/RegeneratedCocD2Repository.ts
+++ b/src/data/RegeneratedCocD2Repository.ts
@@ -61,7 +61,7 @@ export class RegeneratedCocD2Repository implements RegeneratedCocRepository {
             },
             {
                 log: (processed, total) => {
-                    logger.info(`Deleting categoryOptionCombos: ${processed}/${total}`);
+                    logger.info(`Saving categoryOptionCombos: ${processed}/${total}`);
                 },
             }
         );

--- a/src/data/RegeneratedCocD2Repository.ts
+++ b/src/data/RegeneratedCocD2Repository.ts
@@ -1,0 +1,131 @@
+import { D2Api, MetadataResponse } from "types/d2-api";
+import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
+import { Stats } from "domain/entities/Stats";
+import { RegeneratedCocRepository } from "domain/repositories/RegeneratedCocRepository";
+import { getInChunks } from "./dhis2-utils";
+import { writeFileSync } from "fs";
+import logger from "utils/log";
+
+export class RegeneratedCocD2Repository implements RegeneratedCocRepository {
+    constructor(private api: D2Api) {}
+
+    async save(
+        categoryOptionCombos: RegeneratedCoc[],
+        options: { persist: boolean; persistInDisk: boolean }
+    ): Promise<Stats> {
+        const { persist, persistInDisk } = options;
+        const allIds = categoryOptionCombos.map(coc => coc.id);
+
+        const allResponses = await getInChunks(
+            allIds,
+            async (cocIds: string[]) => {
+                const response = await this.api.models.categoryOptionCombos
+                    .get({ filter: { id: { in: cocIds } }, fields: { $owner: true }, paging: false })
+                    .getData();
+
+                const cocsToSave = cocIds.map(cocId => {
+                    const existingCoc = response.objects.find(coc => coc.id === cocId);
+
+                    const cocToSave = categoryOptionCombos.find(coc => coc.id === cocId);
+
+                    if (!cocToSave) throw new Error(`CategoryOptionCombo with id ${cocId} not found.`);
+
+                    return {
+                        ...(existingCoc ?? {}),
+                        id: cocToSave.id,
+                        name: cocToSave.name,
+                        categoryCombo: { id: cocToSave.categoryCombo.id },
+                        categoryOptions: cocToSave.categoryOptions.map(co => ({ id: co.id })),
+                    };
+                });
+
+                return this.api.metadata
+                    .post(
+                        { categoryOptionCombos: cocsToSave },
+                        { importMode: persist ? "COMMIT" : "VALIDATE" }
+                    )
+                    .getData()
+                    .then(res => {
+                        const stats: Stats = { ...res.stats, errorMessage: "", recordsSkipped: [] };
+                        return [{ stats: [stats], cocsToSave }];
+                    })
+                    .catch(err => {
+                        const stats: Stats = {
+                            ...Stats.empty(),
+                            recordsSkipped: cocIds,
+                            errorMessage: this.extractErrorMessageFromResponse(err),
+                            ignored: cocIds.length,
+                        };
+                        return [{ stats: [stats], cocsToSave }];
+                    });
+            },
+            {
+                log: (processed, total) => {
+                    logger.info(`Deleting categoryOptionCombos: ${processed}/${total}`);
+                },
+            }
+        );
+
+        if (persistInDisk) {
+            const currentTime = new Date().toISOString().replace(/[:.]/g, "-");
+            const filePath = `categoryOptionCombos-metadata-${currentTime}.json`;
+            writeFileSync(
+                filePath,
+                JSON.stringify(
+                    { categoryOptionCombos: allResponses.flatMap(response => response.cocsToSave) },
+                    null,
+                    2
+                )
+            );
+        }
+
+        return Stats.combine(allResponses.flatMap(response => response.stats));
+    }
+
+    async deleteByIds(cocIds: string[], options: { persist: boolean }): Promise<Stats> {
+        const { persist } = options;
+        const allStats = await getInChunks(
+            cocIds,
+            async (cocIdsChunks: string[]) => {
+                return this.api.metadata
+                    .post(
+                        { categoryOptionCombos: cocIdsChunks.map(id => ({ id })) },
+                        { importMode: persist ? "COMMIT" : "VALIDATE", importStrategy: "DELETE" }
+                    )
+                    .getData()
+                    .then(res => {
+                        const stats: Stats = { ...res.stats, errorMessage: "", recordsSkipped: [] };
+                        return [stats];
+                    })
+                    .catch(err => {
+                        const stats: Stats = {
+                            ...Stats.empty(),
+                            recordsSkipped: cocIds,
+                            errorMessage: this.extractErrorMessageFromResponse(err),
+                            ignored: cocIds.length,
+                        };
+                        return [stats];
+                    });
+            },
+            {
+                log: (processed, total) => {
+                    logger.info(`Deleting categoryOptionCombos: ${processed}/${total}`);
+                },
+            }
+        );
+
+        return Stats.combine(allStats);
+    }
+
+    private extractErrorMessageFromResponse(err: MetadataResponse): string {
+        const responseError = err as RequestMetadataError;
+        const errorMessage = responseError.response?.data?.response?.typeReports
+            .flatMap(x => x.objectReports)
+            .flatMap(x => x.errorReports)
+            .map(x => x.message)
+            .join("\n");
+        return errorMessage ?? "";
+    }
+}
+
+type RequestMetadataError = { response?: { data?: { response?: MetadataResponse } } };

--- a/src/data/dhis2-utils.ts
+++ b/src/data/dhis2-utils.ts
@@ -46,8 +46,22 @@ export function checkPostEventsResponse(res: EventsPostResponse): void {
     }
 }
 
-export async function getInChunks<T, U>(ids: T[], getter: (idsGroup: T[]) => Promise<U[]>): Promise<U[]> {
-    const objsCollection = await promiseMap(_.chunk(ids, 300), idsGroup => getter(idsGroup));
+export async function getInChunks<T, U>(
+    ids: T[],
+    getter: (idsGroup: T[]) => Promise<U[]>,
+    options?: { log: (processed: number, total: number) => void }
+): Promise<U[]> {
+    const total = ids.length;
+    let processed = 0;
+    const objsCollection = await promiseMap(_.chunk(ids, 300), async idsGroup => {
+        const result = await getter(idsGroup);
+
+        processed += idsGroup.length;
+
+        if (options?.log) options.log(processed, total);
+
+        return result;
+    });
     return _.flatten(objsCollection);
 }
 

--- a/src/data/utils/cocs.ts
+++ b/src/data/utils/cocs.ts
@@ -17,7 +17,7 @@ export function mapCategoryOptionIdToCategoryIndex(categoryCombo: D2CategoryComb
 export function fixCategoryOptionOrder<T extends { id: Id; categoryOptions: Ref[] }>(
     coc: T,
     indexesByCategoryOptionId: Record<string, number>
-) {
+): T {
     const categoryOptionsNotFound = _(coc.categoryOptions)
         .filter(categoryOption => indexesByCategoryOptionId[categoryOption.id] === undefined)
         .value();

--- a/src/data/utils/cocs.ts
+++ b/src/data/utils/cocs.ts
@@ -1,0 +1,38 @@
+import _ from "lodash";
+import { D2CategoryCombo } from "data/CategoryOptionCombosD2Repository";
+import { getId, Id, Ref } from "domain/entities/Base";
+import logger from "utils/log";
+
+export function mapCategoryOptionIdToCategoryIndex(categoryCombo: D2CategoryCombo): Record<Id, number> {
+    return _(categoryCombo.categories)
+        .flatMap((category, categoryIndex) => {
+            return category.categoryOptions.map(categoryOption => {
+                return [categoryOption.id, categoryIndex] as [Id, number];
+            });
+        })
+        .fromPairs()
+        .value();
+}
+
+export function fixCategoryOptionOrder<T extends { id: Id; categoryOptions: Ref[] }>(
+    coc: T,
+    indexesByCategoryOptionId: Record<string, number>
+) {
+    const categoryOptionsNotFound = _(coc.categoryOptions)
+        .filter(categoryOption => indexesByCategoryOptionId[categoryOption.id] === undefined)
+        .value();
+
+    if (!_.isEmpty(categoryOptionsNotFound)) {
+        // Return an empty array as categoryOptions to avoid unsafely relying on its order.
+        const coIds = categoryOptionsNotFound.map(getId).join(", ");
+        const msg = `[coc.id="${coc.id}"] Category options no longer in its categoryCombo: ${coIds}`;
+        logger.debug(msg);
+        return { ...coc, categoryOptions: [] };
+    } else {
+        const categoryOptionsSorted = _(coc.categoryOptions)
+            .sortBy(categoryOption => indexesByCategoryOptionId[categoryOption.id] || 0)
+            .value();
+
+        return { ...coc, categoryOptions: categoryOptionsSorted };
+    }
+}

--- a/src/domain/entities/CategoryCombo.ts
+++ b/src/domain/entities/CategoryCombo.ts
@@ -10,11 +10,6 @@ export type CategoryComboAttrs = {
     categoryOptionCombos: Array<{ id: Id; name: string; categoryOptions: NamedRef[] }>;
 };
 
-export type CategoryOption = {
-    id: Id;
-    name: string;
-};
-
 export class CategoryCombo extends Struct<CategoryComboAttrs>() {
     static build(data: CategoryComboAttrs): Either<ValidationError<CategoryCombo>[], CategoryCombo> {
         const validationErrors = this.validate(data);

--- a/src/domain/entities/CategoryCombo.ts
+++ b/src/domain/entities/CategoryCombo.ts
@@ -1,0 +1,45 @@
+import { Id, NamedRef } from "./Base";
+import { Either } from "./generic/Either";
+import { Struct } from "./generic/Struct";
+import { ValidationError } from "./generic/ValidationError";
+
+export type CategoryComboAttrs = {
+    id: Id;
+    name: string;
+    categories: Array<{ id: Id; options: NamedRef[] }>;
+    categoryOptionCombos: NamedRef[];
+};
+
+export type CategoryOption = {
+    id: Id;
+    name: string;
+};
+
+export class CategoryCombo extends Struct<CategoryComboAttrs>() {
+    static build(data: CategoryComboAttrs): Either<ValidationError<CategoryCombo>[], CategoryCombo> {
+        const validationErrors = this.validate(data);
+        if (validationErrors.length > 0) return Either.error(validationErrors);
+
+        return Either.success(this.create(data));
+    }
+
+    private static validate(data: CategoryComboAttrs): ValidationError<CategoryCombo>[] {
+        const idErrors: ValidationError<CategoryCombo>[] = data.id
+            ? []
+            : [{ property: "id", errors: [{ code: "required" }] }];
+
+        const nameErrors: ValidationError<CategoryCombo>[] = data.name
+            ? []
+            : [{ property: "name", errors: [{ code: "required" }] }];
+
+        const categories: ValidationError<CategoryCombo>[] = data.categories.length
+            ? []
+            : [{ property: "categories", errors: [{ code: "required" }] }];
+
+        const options: ValidationError<CategoryCombo>[] = data.categories.flatMap(category =>
+            category.options.length ? [] : [{ property: "categories", errors: [{ code: "empty_options" }] }]
+        );
+
+        return [...idErrors, ...nameErrors, ...categories, ...options];
+    }
+}

--- a/src/domain/entities/CategoryCombo.ts
+++ b/src/domain/entities/CategoryCombo.ts
@@ -6,8 +6,8 @@ import { ValidationError } from "./generic/ValidationError";
 export type CategoryComboAttrs = {
     id: Id;
     name: string;
-    categories: Array<{ id: Id; options: NamedRef[] }>;
-    categoryOptionCombos: NamedRef[];
+    categories: Array<{ id: Id; categoryOptions: NamedRef[] }>;
+    categoryOptionCombos: Array<{ id: Id; name: string; categoryOptions: NamedRef[] }>;
 };
 
 export type CategoryOption = {
@@ -37,7 +37,9 @@ export class CategoryCombo extends Struct<CategoryComboAttrs>() {
             : [{ property: "categories", errors: [{ code: "required" }] }];
 
         const options: ValidationError<CategoryCombo>[] = data.categories.flatMap(category =>
-            category.options.length ? [] : [{ property: "categories", errors: [{ code: "empty_options" }] }]
+            category.categoryOptions.length
+                ? []
+                : [{ property: "categories", errors: [{ code: "empty_options" }] }]
         );
 
         return [...idErrors, ...nameErrors, ...categories, ...options];

--- a/src/domain/entities/RegeneratedCategoryOptionCombo.ts
+++ b/src/domain/entities/RegeneratedCategoryOptionCombo.ts
@@ -1,0 +1,12 @@
+import { Struct } from "./generic/Struct";
+
+type RegeneratedCategoryOptionComboAttrs = {
+    id: string;
+    name: string;
+};
+
+export class RegeneratedCategoryOptionCombo extends Struct<RegeneratedCategoryOptionComboAttrs>() {
+    static build(data: RegeneratedCategoryOptionComboAttrs): RegeneratedCategoryOptionCombo {
+        return this.create(data);
+    }
+}

--- a/src/domain/entities/RegeneratedCoc.ts
+++ b/src/domain/entities/RegeneratedCoc.ts
@@ -1,0 +1,11 @@
+import { Id, Ref } from "./Base";
+import { Struct } from "./generic/Struct";
+
+type RegeneratedCocAttrs = {
+    id: Id;
+    name: string;
+    categoryCombo: { id: Id };
+    categoryOptions: Ref[];
+};
+
+export class RegeneratedCoc extends Struct<RegeneratedCocAttrs>() {}

--- a/src/domain/entities/generic/Either.ts
+++ b/src/domain/entities/generic/Either.ts
@@ -1,0 +1,84 @@
+/**
+ * Either a success value or an error. Example:
+ *
+ * ```
+ * Either.success<{ message: string }, string>("9")
+ *     .map(s => parseInt(s))
+ *     .flatMap(x => {
+ *         return x > 0 ? Either.success(Math.sqrt(x)) : Either.error({ message: "negative!" });
+ *     })
+ *     .match({
+ *         success: x => console.log(`Value is ${x}`),
+ *         error: error => console.error(`Some error: ${error.message}`),
+ *     }); // prints `Value is 3`
+ * ```
+ */
+
+export class Either<Error, Data> {
+    constructor(public value: EitherValue<Error, Data>) {}
+
+    match<Res>(matchObj: MatchObject<Error, Data, Res>): Res {
+        switch (this.value.type) {
+            case "success":
+                return matchObj.success(this.value.data);
+            case "error":
+                return matchObj.error(this.value.error);
+        }
+    }
+
+    isError(): this is this & { value: EitherValueError<Error> } {
+        return this.value.type === "error";
+    }
+
+    isSuccess(): this is this & { value: EitherValueSuccess<Data> } {
+        return this.value.type === "success";
+    }
+
+    map<Data1>(fn: (data: Data) => Data1): Either<Error, Data1> {
+        return this.flatMap(data => new Either<Error, Data1>({ type: "success", data: fn(data) }));
+    }
+
+    mapError<Error1>(fn: (error: Error) => Error1): Either<Error1, Data> {
+        return this.flatMapError(error => new Either<Error1, Data>({ type: "error", error: fn(error) }));
+    }
+
+    flatMap<Data1>(fn: (data: Data) => Either<Error, Data1>): Either<Error, Data1> {
+        return this.match({
+            success: data => fn(data),
+            error: () => this as Either<Error, any>,
+        });
+    }
+
+    flatMapError<Error1>(fn: (error: Error) => Either<Error1, Data>): Either<Error1, Data> {
+        return this.match({
+            success: () => this as Either<any, Data>,
+            error: error => fn(error),
+        });
+    }
+
+    static error<Error>(error: Error) {
+        return new Either<Error, never>({ type: "error", error });
+    }
+
+    static success<Error, Data>(data: Data) {
+        return new Either<Error, Data>({ type: "success", data });
+    }
+
+    static map2<Error, Res, Data1, Data2>(
+        [either1, either2]: [Either<Error, Data1>, Either<Error, Data2>],
+        fn: (data1: Data1, data2: Data2) => Res
+    ): Either<Error, Res> {
+        return either1.flatMap<Res>(data1 => {
+            return either2.map<Res>(data2 => fn(data1, data2));
+        });
+    }
+}
+
+type EitherValueError<Error> = { type: "error"; error: Error; data?: never };
+type EitherValueSuccess<Data> = { type: "success"; error?: never; data: Data };
+type EitherValue<Error, Data> = EitherValueError<Error> | EitherValueSuccess<Data>;
+
+type MatchObject<Error, Data, Res> = {
+    success: (data: Data) => Res;
+    error: (error: Error) => Res;
+};

--- a/src/domain/entities/generic/Struct.ts
+++ b/src/domain/entities/generic/Struct.ts
@@ -1,0 +1,45 @@
+/**
+ * Base class for typical classes with attributes. Features: create, update.
+ *
+ * ```
+ * class Counter extends Struct<{ id: Id; value: number }>() {
+ *     add(value: number): Counter {
+ *         return this._update({ value: this.value + value });
+ *     }
+ * }
+ *
+ * const counter1 = Counter.create({ id: "some-counter", value: 1 });
+ * const counter2 = counter1._update({ value: 2 });
+ * ```
+ */
+
+export function Struct<Attrs>() {
+    abstract class Base {
+        constructor(_attributes: Attrs) {
+            Object.assign(this, _attributes);
+        }
+
+        _getAttributes(): Attrs {
+            const entries = Object.getOwnPropertyNames(this).map(key => [key, (this as any)[key]]);
+            return Object.fromEntries(entries) as Attrs;
+        }
+
+        protected _update(partialAttrs: Partial<Attrs>): this {
+            const ParentClass = this.constructor as new (values: Attrs) => typeof this;
+            return new ParentClass({ ...this._getAttributes(), ...partialAttrs });
+        }
+
+        static create<U extends Base>(this: new (attrs: Attrs) => U, attrs: Attrs): U {
+            return new this(attrs);
+        }
+    }
+
+    return Base as {
+        new (values: Attrs): Attrs & Base;
+        create: typeof Base["create"];
+    };
+}
+
+const GenericStruct = Struct<unknown>();
+
+export type GenericStructInstance = InstanceType<typeof GenericStruct>;

--- a/src/domain/entities/generic/ValidationError.ts
+++ b/src/domain/entities/generic/ValidationError.ts
@@ -1,0 +1,4 @@
+export type ValidationError<T> = {
+    property: keyof T;
+    errors: Array<{ code: string }>;
+};

--- a/src/domain/repositories/CategoryComboD2Repository.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.ts
@@ -1,7 +1,8 @@
 import _ from "lodash";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
-import { D2Api } from "../../types/d2-api";
+import { D2Api, Id } from "../../types/d2-api";
 import { CategoryComboRepository } from "./CategoryComboRepository";
+import logger from "utils/log";
 
 export class CategoryComboD2Repository implements CategoryComboRepository {
     constructor(private api: D2Api) {}
@@ -34,7 +35,7 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                     id: true,
                     name: true,
                     categories: { id: true, categoryOptions: { id: true, name: true } },
-                    categoryOptionCombos: { id: true, name: true },
+                    categoryOptionCombos: { id: true, name: true, categoryOptions: { id: true, name: true } },
                 },
                 page: options.page,
                 pageSize: options.pageSize,
@@ -48,12 +49,12 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                     name: catComboData.name,
                     categories: catComboData.categories.map(catData => ({
                         id: catData.id,
-                        options: catData.categoryOptions.map(optData => ({
+                        categoryOptions: catData.categoryOptions.map(optData => ({
                             id: optData.id,
                             name: optData.name,
                         })),
                     })),
-                    categoryOptionCombos: catComboData.categoryOptionCombos,
+                    categoryOptionCombos: this.reorderCategoryOptionCombos(catComboData),
                 });
 
                 if (categoryCombo.isError()) {
@@ -71,5 +72,45 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
             .value();
 
         return { objects: categoryCombos, pager: response.pager };
+    }
+
+    private reorderCategoryOptionCombos(catComboData: {
+        id: Id;
+        categories: Array<{ id: Id; categoryOptions: Array<{ id: Id; name: string }> }>;
+        categoryOptionCombos: Array<{
+            id: Id;
+            name: string;
+            categoryOptions: Array<{ id: Id; name: string }>;
+        }>;
+    }) {
+        const optionOrderById = new Map<Id, number>();
+        let index = 0;
+
+        catComboData.categories.forEach(category => {
+            category.categoryOptions.forEach(categoryOption => {
+                optionOrderById.set(categoryOption.id, index);
+                index += 1;
+            });
+        });
+
+        return catComboData.categoryOptionCombos.map(categoryOptionCombo => {
+            const missingOptions = categoryOptionCombo.categoryOptions.filter(
+                categoryOption => !optionOrderById.has(categoryOption.id)
+            );
+
+            if (!_.isEmpty(missingOptions)) {
+                const missingIds = missingOptions.map(categoryOption => categoryOption.id).join(", ");
+                logger.debug(
+                    `[categoryCombo.id="${catComboData.id}"][coc.id="${categoryOptionCombo.id}"] Category options not found in categoryCombo: ${missingIds}`
+                );
+                return { ...categoryOptionCombo, categoryOptions: [] };
+            }
+
+            const sortedOptions = [...categoryOptionCombo.categoryOptions].sort((left, right) => {
+                return (optionOrderById.get(left.id) ?? 0) - (optionOrderById.get(right.id) ?? 0);
+            });
+
+            return { ...categoryOptionCombo, categoryOptions: sortedOptions };
+        });
     }
 }

--- a/src/domain/repositories/CategoryComboD2Repository.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 import { D2Api, Id } from "../../types/d2-api";
 import { CategoryComboRepository } from "./CategoryComboRepository";
-import logger from "utils/log";
+import { fixCategoryOptionOrder, mapCategoryOptionIdToCategoryIndex } from "data/utils/cocs";
 
 export class CategoryComboD2Repository implements CategoryComboRepository {
     constructor(private api: D2Api) {}
@@ -37,6 +37,7 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                     categories: { id: true, categoryOptions: { id: true, name: true } },
                     categoryOptionCombos: { id: true, name: true, categoryOptions: { id: true, name: true } },
                 },
+                filter: { id: { eq: "GmXXE8fiCK5" } },
                 page: options.page,
                 pageSize: options.pageSize,
             })
@@ -74,43 +75,20 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
         return { objects: categoryCombos, pager: response.pager };
     }
 
-    private reorderCategoryOptionCombos(catComboData: {
-        id: Id;
-        categories: Array<{ id: Id; categoryOptions: Array<{ id: Id; name: string }> }>;
-        categoryOptionCombos: Array<{
-            id: Id;
-            name: string;
-            categoryOptions: Array<{ id: Id; name: string }>;
-        }>;
-    }) {
-        const optionOrderById = new Map<Id, number>();
-        let index = 0;
-
-        catComboData.categories.forEach(category => {
-            category.categoryOptions.forEach(categoryOption => {
-                optionOrderById.set(categoryOption.id, index);
-                index += 1;
-            });
-        });
-
+    private reorderCategoryOptionCombos(catComboData: D2ApiCategoryCombo) {
         return catComboData.categoryOptionCombos.map(categoryOptionCombo => {
-            const missingOptions = categoryOptionCombo.categoryOptions.filter(
-                categoryOption => !optionOrderById.has(categoryOption.id)
-            );
-
-            if (!_.isEmpty(missingOptions)) {
-                const missingIds = missingOptions.map(categoryOption => categoryOption.id).join(", ");
-                logger.debug(
-                    `[categoryCombo.id="${catComboData.id}"][coc.id="${categoryOptionCombo.id}"] Category options not found in categoryCombo: ${missingIds}`
-                );
-                return { ...categoryOptionCombo, categoryOptions: [] };
-            }
-
-            const sortedOptions = [...categoryOptionCombo.categoryOptions].sort((left, right) => {
-                return (optionOrderById.get(left.id) ?? 0) - (optionOrderById.get(right.id) ?? 0);
-            });
-
-            return { ...categoryOptionCombo, categoryOptions: sortedOptions };
+            const indexesByCategoryOptionId = mapCategoryOptionIdToCategoryIndex(catComboData);
+            return fixCategoryOptionOrder(categoryOptionCombo, indexesByCategoryOptionId);
         });
     }
 }
+
+type D2ApiCategoryCombo = {
+    id: Id;
+    categories: Array<{ id: Id; categoryOptions: Array<{ id: Id; name: string }> }>;
+    categoryOptionCombos: Array<{
+        id: Id;
+        name: string;
+        categoryOptions: Array<{ id: Id; name: string }>;
+    }>;
+};

--- a/src/domain/repositories/CategoryComboD2Repository.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.ts
@@ -1,0 +1,75 @@
+import _ from "lodash";
+import { CategoryCombo } from "domain/entities/CategoryCombo";
+import { D2Api } from "../../types/d2-api";
+import { CategoryComboRepository } from "./CategoryComboRepository";
+
+export class CategoryComboD2Repository implements CategoryComboRepository {
+    constructor(private api: D2Api) {}
+
+    async getAll(): Promise<CategoryCombo[]> {
+        return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [] });
+    }
+
+    async getAllByPages(options: {
+        page: number;
+        pageSize: number;
+        categoryCombos: CategoryCombo[];
+    }): Promise<CategoryCombo[]> {
+        const { page, pageSize, categoryCombos } = options;
+
+        const response = await this.getCategoryCombos({ page, pageSize });
+        const newRecords = [...categoryCombos, ...response.objects];
+        const pager = response.pager;
+        if (pager.page >= pager.pageCount) {
+            return newRecords;
+        } else {
+            return this.getAllByPages({ page: page + 1, pageSize, categoryCombos: newRecords });
+        }
+    }
+
+    private async getCategoryCombos(options: { page: number; pageSize: number }) {
+        const response = await this.api.models.categoryCombos
+            .get({
+                fields: {
+                    id: true,
+                    name: true,
+                    categories: { id: true, categoryOptions: { id: true, name: true } },
+                    categoryOptionCombos: { id: true, name: true },
+                },
+                page: options.page,
+                pageSize: options.pageSize,
+            })
+            .getData();
+
+        const categoryCombos = _(response.objects)
+            .map(catComboData => {
+                const categoryCombo = CategoryCombo.build({
+                    id: catComboData.id,
+                    name: catComboData.name,
+                    categories: catComboData.categories.map(catData => ({
+                        id: catData.id,
+                        options: catData.categoryOptions.map(optData => ({
+                            id: optData.id,
+                            name: optData.name,
+                        })),
+                    })),
+                    categoryOptionCombos: catComboData.categoryOptionCombos,
+                });
+
+                if (categoryCombo.isError()) {
+                    console.warn(
+                        `Invalid CategoryCombo name=${catComboData.name} id=${catComboData.id}:`,
+                        categoryCombo.value.error
+                            .map(e => `${e.property}: ${e.errors.map(err => err.code).join(", ")}`)
+                            .join("; ")
+                    );
+                }
+
+                return categoryCombo.value.data;
+            })
+            .compact()
+            .value();
+
+        return { objects: categoryCombos, pager: response.pager };
+    }
+}

--- a/src/domain/repositories/CategoryComboD2Repository.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.ts
@@ -37,7 +37,6 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                     categories: { id: true, categoryOptions: { id: true, name: true } },
                     categoryOptionCombos: { id: true, name: true, categoryOptions: { id: true, name: true } },
                 },
-                filter: { id: { eq: "GmXXE8fiCK5" } },
                 page: options.page,
                 pageSize: options.pageSize,
             })

--- a/src/domain/repositories/CategoryComboRepository.ts
+++ b/src/domain/repositories/CategoryComboRepository.ts
@@ -1,0 +1,5 @@
+import { CategoryCombo } from "domain/entities/CategoryCombo";
+
+export interface CategoryComboRepository {
+    getAll(): Promise<CategoryCombo[]>;
+}

--- a/src/domain/repositories/RegeneratedCocRepository.ts
+++ b/src/domain/repositories/RegeneratedCocRepository.ts
@@ -1,0 +1,8 @@
+import { Id } from "domain/entities/Base";
+import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
+import { Stats } from "domain/entities/Stats";
+
+export interface RegeneratedCocRepository {
+    save(cocs: RegeneratedCoc[], options: { persist: boolean; persistInDisk: boolean }): Promise<Stats>;
+    deleteByIds(cocIds: Id[], options: { persist: boolean }): Promise<Stats>;
+}

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -1,0 +1,60 @@
+import logger from "utils/log";
+import { getUid } from "data/dhis2";
+import { NamedRef } from "domain/entities/Base";
+import { CategoryCombo } from "domain/entities/CategoryCombo";
+import { CategoryComboRepository } from "domain/repositories/CategoryComboRepository";
+
+export class RegenerateCocsUseCase {
+    constructor(private options: { categoryComboRepository: CategoryComboRepository }) {}
+
+    async execute(): Promise<UseCaseResult> {
+        const categoryCombos = await this.getCategoryCombos();
+
+        const categoryComboWithGeneratedCocs = categoryCombos.map(categoryCombo =>
+            this.generateCombinationsFromCategoryCombo(categoryCombo)
+        );
+
+        return { result: categoryComboWithGeneratedCocs };
+    }
+
+    private async getCategoryCombos(): Promise<CategoryCombo[]> {
+        logger.info("Fetching categoryOptionCombos...");
+        const categoryCombos = await this.options.categoryComboRepository.getAll();
+        logger.info(`${categoryCombos.length} categoryOptionCombos found.`);
+        return categoryCombos;
+    }
+
+    private generateCombinationsFromCategoryCombo(categoryCombo: CategoryCombo): {
+        categoryCombo: CategoryCombo;
+        categoryOptionCombos: NamedRef[];
+    } {
+        const allOptions = categoryCombo.categories.map(cat => cat.options);
+
+        const combinations = this.cartesianProduct(allOptions);
+
+        const categoryOptionCombos = combinations.map((combination): NamedRef => {
+            const combinationName = combination.map(opt => opt.name).join(", ");
+            return { id: getUid(combinationName, ""), name: combinationName };
+        });
+
+        logger.debug(
+            `Regenerated ${categoryOptionCombos.length} combinations for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
+        );
+
+        return { categoryCombo, categoryOptionCombos };
+    }
+
+    private cartesianProduct<T>(arrays: T[][]): T[][] {
+        if (arrays.length === 0) return [[]];
+
+        return arrays.reduce<T[][]>(
+            (accumulator, currentArray) =>
+                accumulator.flatMap(combination => currentArray.map(item => [...combination, item])),
+            [[]]
+        );
+    }
+}
+
+type UseCaseResult = {
+    result: Array<{ categoryCombo: CategoryCombo; categoryOptionCombos: NamedRef[] }>;
+};

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -27,21 +27,51 @@ export class RegenerateCocsUseCase {
     private generateCombinationsFromCategoryCombo(categoryCombo: CategoryCombo): {
         categoryCombo: CategoryCombo;
         categoryOptionCombos: NamedRef[];
+        missingCategoryOptionCombos: NamedRef[];
     } {
-        const allOptions = categoryCombo.categories.map(cat => cat.options);
+        const allOptions = categoryCombo.categories.map(cat => cat.categoryOptions);
 
         const combinations = this.cartesianProduct(allOptions);
 
+        const existingCategoryOptionCombosByKey = new Map<
+            string,
+            CategoryCombo["categoryOptionCombos"][number]
+        >(
+            categoryCombo.categoryOptionCombos.map(categoryOptionCombo => [
+                this.getCategoryOptionComboKey(categoryOptionCombo.categoryOptions),
+                categoryOptionCombo,
+            ])
+        );
+
         const categoryOptionCombos = combinations.map((combination): NamedRef => {
             const combinationName = combination.map(opt => opt.name).join(", ");
+            const combinationKey = this.getCategoryOptionComboKey(combination);
+            const existingCategoryOptionCombo = existingCategoryOptionCombosByKey.get(combinationKey);
+            if (existingCategoryOptionCombo) {
+                return { id: existingCategoryOptionCombo.id, name: existingCategoryOptionCombo.name };
+            }
+
             return { id: getUid(combinationName, ""), name: combinationName };
         });
+
+        const regeneratedCategoryOptionComboKeys = new Set(
+            combinations.map(combination => this.getCategoryOptionComboKey(combination))
+        );
+        const missingCategoryOptionCombos = categoryCombo.categoryOptionCombos.filter(
+            categoryOptionCombo =>
+                !regeneratedCategoryOptionComboKeys.has(
+                    this.getCategoryOptionComboKey(categoryOptionCombo.categoryOptions)
+                )
+        );
 
         logger.debug(
             `Regenerated ${categoryOptionCombos.length} combinations for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
         );
+        logger.debug(
+            `Found ${missingCategoryOptionCombos.length} missing combinations for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
+        );
 
-        return { categoryCombo, categoryOptionCombos };
+        return { categoryCombo, categoryOptionCombos, missingCategoryOptionCombos };
     }
 
     private cartesianProduct<T>(arrays: T[][]): T[][] {
@@ -53,8 +83,16 @@ export class RegenerateCocsUseCase {
             [[]]
         );
     }
+
+    private getCategoryOptionComboKey(categoryOptions: NamedRef[]): string {
+        return categoryOptions.map(categoryOption => categoryOption.id).join("|");
+    }
 }
 
 type UseCaseResult = {
-    result: Array<{ categoryCombo: CategoryCombo; categoryOptionCombos: NamedRef[] }>;
+    result: Array<{
+        categoryCombo: CategoryCombo;
+        categoryOptionCombos: NamedRef[];
+        missingCategoryOptionCombos: NamedRef[];
+    }>;
 };

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -1,20 +1,61 @@
+import _ from "lodash";
 import logger from "utils/log";
 import { getUid } from "data/dhis2";
 import { NamedRef } from "domain/entities/Base";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 import { CategoryComboRepository } from "domain/repositories/CategoryComboRepository";
+import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
+import { RegeneratedCocRepository } from "domain/repositories/RegeneratedCocRepository";
+import { Stats } from "domain/entities/Stats";
 
 export class RegenerateCocsUseCase {
-    constructor(private options: { categoryComboRepository: CategoryComboRepository }) {}
+    constructor(
+        private options: {
+            categoryComboRepository: CategoryComboRepository;
+            regeneratedCocRepository: RegeneratedCocRepository;
+        }
+    ) {}
 
-    async execute(): Promise<UseCaseResult> {
+    async execute(options: UseCaseArgs): Promise<RegenerateCocsUseCaseResult> {
         const categoryCombos = await this.getCategoryCombos();
-
         const categoryComboWithGeneratedCocs = categoryCombos.map(categoryCombo =>
             this.generateCombinationsFromCategoryCombo(categoryCombo)
         );
 
-        return { result: categoryComboWithGeneratedCocs };
+        await this.saveCocs(categoryComboWithGeneratedCocs, options);
+        await this.deleteCocs(categoryComboWithGeneratedCocs, options);
+
+        return { categoryCombos: categoryComboWithGeneratedCocs };
+    }
+
+    private async saveCocs(
+        categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"],
+        options: UseCaseArgs
+    ): Promise<Stats> {
+        const cocsToCreate = categoryComboWithGeneratedCocs.flatMap(item => item.categoryOptionCombos);
+        logger.info(`Saving ${cocsToCreate.length} categoryOptionCombos...`);
+        const saveStats = await this.options.regeneratedCocRepository.save(cocsToCreate, {
+            persist: options.persist,
+            persistInDisk: true,
+        });
+        logger.info(`Finished: ${JSON.stringify(saveStats, null, 2)}`);
+        return saveStats;
+    }
+
+    private async deleteCocs(
+        categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"],
+        options: UseCaseArgs
+    ): Promise<Stats> {
+        const { deleteCocs } = options;
+        const cocIdsToDelete = categoryComboWithGeneratedCocs.flatMap(item =>
+            item.cocsToDelete.map(coc => coc.id)
+        );
+        logger.info(`Deleting ${cocIdsToDelete.length} categoryOptionCombos...`);
+        const deleteStats = await this.options.regeneratedCocRepository.deleteByIds(cocIdsToDelete, {
+            persist: deleteCocs,
+        });
+        logger.info(`Finished: ${JSON.stringify(deleteStats, null, 2)}`);
+        return deleteStats;
     }
 
     private async getCategoryCombos(): Promise<CategoryCombo[]> {
@@ -26,8 +67,9 @@ export class RegenerateCocsUseCase {
 
     private generateCombinationsFromCategoryCombo(categoryCombo: CategoryCombo): {
         categoryCombo: CategoryCombo;
-        categoryOptionCombos: NamedRef[];
-        missingCategoryOptionCombos: NamedRef[];
+        categoryOptionCombos: RegeneratedCoc[];
+        allCategoryOptionCombos: RegeneratedCoc[];
+        cocsToDelete: RegeneratedCoc[];
     } {
         const allOptions = categoryCombo.categories.map(cat => cat.categoryOptions);
 
@@ -43,21 +85,44 @@ export class RegenerateCocsUseCase {
             ])
         );
 
-        const categoryOptionCombos = combinations.map((combination): NamedRef => {
-            const combinationName = combination.map(opt => opt.name).join(", ");
-            const combinationKey = this.getCategoryOptionComboKey(combination);
-            const existingCategoryOptionCombo = existingCategoryOptionCombosByKey.get(combinationKey);
-            if (existingCategoryOptionCombo) {
-                return { id: existingCategoryOptionCombo.id, name: existingCategoryOptionCombo.name };
-            }
+        const categoryOptionCombos = combinations.map(
+            (combination): { regeneratedCoc: RegeneratedCoc; toBeSaved: boolean } => {
+                const combinationName = combination.map(opt => opt.name).join(", ");
 
-            return { id: getUid(combinationName, ""), name: combinationName };
-        });
+                const combinationKey = this.getCategoryOptionComboKey(combination);
+                const existingCategoryOptionCombo = existingCategoryOptionCombosByKey.get(combinationKey);
+
+                if (existingCategoryOptionCombo) {
+                    const regeneratedCoc = RegeneratedCoc.create({
+                        id: existingCategoryOptionCombo.id,
+                        name: combinationName,
+                        categoryCombo: { id: categoryCombo.id },
+                        categoryOptions: combination,
+                    });
+
+                    return {
+                        regeneratedCoc,
+                        toBeSaved: existingCategoryOptionCombo.name !== combinationName,
+                    };
+                }
+
+                return {
+                    regeneratedCoc: RegeneratedCoc.create({
+                        id: getUid(combinationKey, categoryCombo.id),
+                        name: combinationName,
+                        categoryCombo: { id: categoryCombo.id },
+                        categoryOptions: combination,
+                    }),
+                    toBeSaved: true,
+                };
+            }
+        );
 
         const regeneratedCategoryOptionComboKeys = new Set(
             combinations.map(combination => this.getCategoryOptionComboKey(combination))
         );
-        const missingCategoryOptionCombos = categoryCombo.categoryOptionCombos.filter(
+
+        const cocsToDelete = categoryCombo.categoryOptionCombos.filter(
             categoryOptionCombo =>
                 !regeneratedCategoryOptionComboKeys.has(
                     this.getCategoryOptionComboKey(categoryOptionCombo.categoryOptions)
@@ -67,11 +132,26 @@ export class RegenerateCocsUseCase {
         logger.debug(
             `Regenerated ${categoryOptionCombos.length} combinations for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
         );
+
         logger.debug(
-            `Found ${missingCategoryOptionCombos.length} missing combinations for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
+            `Found ${cocsToDelete.length} combinations to delete for categoryCombo ${categoryCombo.name} (${categoryCombo.id})`
         );
 
-        return { categoryCombo, categoryOptionCombos, missingCategoryOptionCombos };
+        const cocsToSave = categoryOptionCombos.filter(coc => coc.toBeSaved).map(coc => coc.regeneratedCoc);
+
+        return {
+            categoryCombo,
+            categoryOptionCombos: cocsToSave,
+            allCategoryOptionCombos: categoryOptionCombos.map(coc => coc.regeneratedCoc),
+            cocsToDelete: cocsToDelete.map(coc =>
+                RegeneratedCoc.create({
+                    id: coc.id,
+                    name: coc.name,
+                    categoryCombo: { id: categoryCombo.id },
+                    categoryOptions: coc.categoryOptions,
+                })
+            ),
+        };
     }
 
     private cartesianProduct<T>(arrays: T[][]): T[][] {
@@ -85,14 +165,20 @@ export class RegenerateCocsUseCase {
     }
 
     private getCategoryOptionComboKey(categoryOptions: NamedRef[]): string {
-        return categoryOptions.map(categoryOption => categoryOption.id).join("|");
+        return _(categoryOptions)
+            .map(categoryOption => categoryOption.id)
+            .uniq()
+            .join("|");
     }
 }
 
-type UseCaseResult = {
-    result: Array<{
+export type RegenerateCocsUseCaseResult = {
+    categoryCombos: Array<{
         categoryCombo: CategoryCombo;
-        categoryOptionCombos: NamedRef[];
-        missingCategoryOptionCombos: NamedRef[];
+        categoryOptionCombos: RegeneratedCoc[];
+        allCategoryOptionCombos: RegeneratedCoc[];
+        cocsToDelete: RegeneratedCoc[];
     }>;
 };
+
+type UseCaseArgs = { deleteCocs: boolean; persist: boolean };

--- a/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
+++ b/src/domain/usecases/user-monitoring/permission-fixer/__tests__/RunUserPermissionTest.data.ts
@@ -184,13 +184,10 @@ export const excludedRoles: NamedRef[] = [
 export const fakeInvalidUserWithExcludedRoles: PermissionFixerUser = {
     ...fakeInvalidUser,
     userCredentials: {
-        ...fakeInvalidUser.userCredentials!,
-        userRoles: [
-            ...fakeInvalidUser.userCredentials!.userRoles,
-            ...excludedRoles,
-        ],
+        ...fakeInvalidUser.userCredentials,
+        userRoles: [...fakeInvalidUser.userCredentials.userRoles, ...excludedRoles],
     },
-    userRoles: [...fakeInvalidUser.userRoles!, ...excludedRoles],
+    userRoles: [...fakeInvalidUser.userRoles, ...excludedRoles],
 };
 
 export const fakeUserWithoutUserGroup: PermissionFixerUser = {

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -1,6 +1,6 @@
 import { command, flag } from "cmd-ts";
 import { RegeneratedCocD2Repository } from "data/RegeneratedCocD2Repository";
-import { CategoryComboD2Repository } from "domain/repositories/CategoryComboD2Repository";
+import { CategoryComboD2Repository } from "data/CategoryComboD2Repository";
 import { RegenerateCocsUseCase, RegenerateCocsUseCaseResult } from "domain/usecases/RegenerateCocsUseCase";
 import { writeFileSync } from "fs";
 import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
@@ -16,7 +16,7 @@ export const regenerateCocsCmd = command({
             description: "persist the change to DHIS (default: false)",
         }),
         deleteCocs: flag({
-            long: "deleteCocs",
+            long: "delete-cocs",
             description: "delete obsolete categoryOptionCombos (default: false)",
         }),
     },

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -1,0 +1,28 @@
+import { command } from "cmd-ts";
+import { CategoryComboD2Repository } from "domain/repositories/CategoryComboD2Repository";
+import { RegenerateCocsUseCase } from "domain/usecases/RegenerateCocsUseCase";
+import { writeFileSync } from "fs";
+import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
+
+export const regenerateCocsCmd = command({
+    name: "regenerate",
+    description: "Regenerate categoryOptionCombos for Category Combos",
+    args: {
+        ...getApiUrlOptions(),
+    },
+    handler: async args => {
+        const api = getD2ApiFromArgs(args);
+        const categoryComboRepository = new CategoryComboD2Repository(api);
+        const useCase = new RegenerateCocsUseCase({ categoryComboRepository });
+
+        try {
+            const result = await useCase.execute();
+            const fileName = "regenerated-category-option-combos.json";
+            writeFileSync(fileName, JSON.stringify(result, null, 2));
+            console.log(`Regenerated categoryOptionCombos saved to ${fileName}`);
+        } catch (error) {
+            console.error("Error regenerating categoryOptionCombos:", error);
+            process.exit(1);
+        }
+    },
+});

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -8,7 +8,7 @@ import logger from "utils/log";
 
 export const regenerateCocsCmd = command({
     name: "regenerate",
-    description: "Regenerate categoryOptionCombos for Category Combos",
+    description: "Regenerate categoryOptionCombos for categoryCombos",
     args: {
         ...getApiUrlOptions(),
         persist: flag({

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -1,28 +1,54 @@
-import { command } from "cmd-ts";
+import { command, flag } from "cmd-ts";
+import { RegeneratedCocD2Repository } from "data/RegeneratedCocD2Repository";
 import { CategoryComboD2Repository } from "domain/repositories/CategoryComboD2Repository";
-import { RegenerateCocsUseCase } from "domain/usecases/RegenerateCocsUseCase";
+import { RegenerateCocsUseCase, RegenerateCocsUseCaseResult } from "domain/usecases/RegenerateCocsUseCase";
 import { writeFileSync } from "fs";
 import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
+import logger from "utils/log";
 
 export const regenerateCocsCmd = command({
     name: "regenerate",
     description: "Regenerate categoryOptionCombos for Category Combos",
     args: {
         ...getApiUrlOptions(),
+        persist: flag({
+            long: "persist",
+            description: "persist the change to DHIS (default: false)",
+        }),
+        deleteCocs: flag({
+            long: "deleteCocs",
+            description: "delete obsolete categoryOptionCombos (default: false)",
+        }),
     },
     handler: async args => {
         const api = getD2ApiFromArgs(args);
         const categoryComboRepository = new CategoryComboD2Repository(api);
-        const useCase = new RegenerateCocsUseCase({ categoryComboRepository });
+        const regeneratedCocRepository = new RegeneratedCocD2Repository(api);
+        const useCase = new RegenerateCocsUseCase({ categoryComboRepository, regeneratedCocRepository });
 
         try {
-            const result = await useCase.execute();
-            const fileName = "regenerated-category-option-combos.json";
-            writeFileSync(fileName, JSON.stringify(result, null, 2));
-            console.log(`Regenerated categoryOptionCombos saved to ${fileName}`);
+            const response = await useCase.execute({ persist: args.persist, deleteCocs: args.deleteCocs });
+            generateJsonReport(response.categoryCombos);
         } catch (error) {
-            console.error("Error regenerating categoryOptionCombos:", error);
+            logger.error(`Error regenerating categoryOptionCombos: ${JSON.stringify(error, null, 2)}`);
             process.exit(1);
         }
     },
 });
+
+function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categoryCombos"]): void {
+    const currentTime = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `regenerated-category-option-combos-${currentTime}.json`;
+
+    const jsonReport = categoryCombos.map(catCombo => ({
+        id: catCombo.categoryCombo.id,
+        name: catCombo.categoryCombo.name,
+        totalCocsGenerated: catCombo.allCategoryOptionCombos.length,
+        totalCocsSaved: catCombo.categoryOptionCombos.length,
+        totalCocsToDelete: catCombo.cocsToDelete.length,
+        cocsToDelete: catCombo.cocsToDelete.map(coc => ({ id: coc.id, name: coc.name })),
+    }));
+
+    writeFileSync(fileName, JSON.stringify(jsonReport, null, 2));
+    logger.info(`Report generated: ${fileName}`);
+}

--- a/src/scripts/commands/categoryOptionCombos.ts
+++ b/src/scripts/commands/categoryOptionCombos.ts
@@ -1,4 +1,5 @@
 import { subcommands } from "cmd-ts";
+import { regenerateCocsCmd } from "./category-option-combos/regenerateCocsCmd";
 import { translateCocsCmd } from "./category-option-combos/translateCocsCmd";
 
 export function getCommand() {
@@ -6,6 +7,7 @@ export function getCommand() {
         name: "categoryOptionCombos",
         cmds: {
             translate: translateCocsCmd,
+            regenerate: regenerateCocsCmd,
         },
     });
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/869btxm35

### :memo: Implementation

Regenerate categoryOptionCombos from `categoryCombo.categories[].categoryOptions[]` for all the `categoryCombos` on the server and delete obsolete `categoryOptionCombos`.

By default both operations (create+update and delete) are being executed using the `VALIDATE` importMode (dry run). Use the `--persist` flag to apply changes (create+update) and `--deleteCocs` to confirm the deletion of obsolete `categoryOptionCombos`.

```shell
yarn start categoryOptionCombos regenerate \
    --url=https://play.im.dhis2.org/stable-2-40-10 \
    --auth="admin:district" \
    --persist \
    --delete-cocs
```

Some notes:

- For servers with thousands of `categoryOptionCombos` the deleting process could take a lot of time.
- categoryOptionCombos are being created/updated using the `/api/categoryOptionCombos` endpoint. Sometimes I had to clean the cache from `Data administration -> Maintenance -> Clear application cache` to changes being visible from the `/api/categoryCombos?fields=id,categoryOptionCombos` endpoint.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

#869btxm35