### PR TITLE
add sql script generation for deleting obsolete cocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,7 +1117,7 @@ yarn start categoryOptionCombos regenerate \
     --delete-cocs
 ```
 
-Save categoryOptionCombos and generating a sql script for deleting categoryOptionCombos.
+Save categoryOptionCombos and generating a sql script for deleting categoryOptionCombos. if you remove the `persist` flag it will only generate the sql.
 
 ```shell
 yarn start categoryOptionCombos regenerate \

--- a/README.md
+++ b/README.md
@@ -1117,6 +1117,17 @@ yarn start categoryOptionCombos regenerate \
     --delete-cocs
 ```
 
+You can also include a comma separated list if you want to regenerate specific category Combos.
+
+```shell
+yarn start categoryOptionCombos regenerate \
+    --url=https://play.im.dhis2.org/dev \
+    --auth="admin:district" \
+    --persist \
+    --delete-cocs \
+    --cat-combos-ids=id1,id2,id3
+```
+
 Save categoryOptionCombos and generating a sql script for deleting categoryOptionCombos. if you remove the `persist` flag it will only generate the sql.
 
 ```shell
@@ -1124,7 +1135,7 @@ yarn start categoryOptionCombos regenerate \
     --url=https://play.im.dhis2.org/dev \
     --auth="admin:district" \
     --persist \
-    --generate-sql-delete-script
+    --generate-sql-delete-script \
 ```
 
 Before deleting a `categoryOptionCombo` the script checks for existing data in the `datavalue` and `datavalueaudit` tables. If you have thousands or millions of records, this process can be very slow.

--- a/README.md
+++ b/README.md
@@ -1125,7 +1125,7 @@ yarn start categoryOptionCombos regenerate \
     --auth="admin:district" \
     --persist \
     --delete-cocs \
-    --cat-combos-ids=id1,id2,id3
+    --category-combo-ids=id1,id2,id3
 ```
 
 Save categoryOptionCombos and generating a sql script for deleting categoryOptionCombos. if you remove the `persist` flag it will only generate the sql.
@@ -1135,7 +1135,7 @@ yarn start categoryOptionCombos regenerate \
     --url=https://play.im.dhis2.org/dev \
     --auth="admin:district" \
     --persist \
-    --generate-sql-delete-script \
+    --generate-sql-delete-script
 ```
 
 Before deleting a `categoryOptionCombo` the script checks for existing data in the `datavalue` and `datavalueaudit` tables. If you have thousands or millions of records, this process can be very slow.

--- a/README.md
+++ b/README.md
@@ -1105,10 +1105,35 @@ Regenerate categoryOptionCombos from `categoryCombo.categories[].categoryOptions
 
 By default both operations (create+update and delete) are being executed using the `VALIDATE` importMode (dry run). Use the --persist flag to apply changes (create+update) and --delete-cocs to confirm the deletion of obsolete categoryOptionCombos.
 
+In some cases deleting cocs through the API could be really slow. You can pass the `--generate-sql-delete-script` to generate a sql script that you can run directly against the database.
+
+Save and delete categoryOptionCombos
+
 ```shell
 yarn start categoryOptionCombos regenerate \
     --url=https://play.im.dhis2.org/dev \
     --auth="admin:district" \
     --persist \
     --delete-cocs
+```
+
+Save categoryOptionCombos and generating a sql script for deleting categoryOptionCombos.
+
+```shell
+yarn start categoryOptionCombos regenerate \
+    --url=https://play.im.dhis2.org/dev \
+    --auth="admin:district" \
+    --persist \
+    --generate-sql-delete-script
+```
+
+Before deleting a `categoryOptionCombo` the script checks for existing data in the `datavalue` and `datavalueaudit` tables. If you have thousands or millions of records, this process can be very slow.
+
+Adding an index to these tables improves performance significantly:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_datavalue_catoptcombo ON datavalue(categoryoptioncomboid);
+CREATE INDEX CONCURRENTLY idx_datavalue_attoptcombo ON datavalue(attributeoptioncomboid);
+CREATE INDEX CONCURRENTLY idx_datavalueaudit_catoptcombo ON datavalueaudit(categoryoptioncomboid);
+CREATE INDEX CONCURRENTLY idx_datavalueaudit_attoptcombo ON datavalueaudit(attributeoptioncomboid);
 ```

--- a/src/data/CategoryComboD2Repository.ts
+++ b/src/data/CategoryComboD2Repository.ts
@@ -7,28 +7,29 @@ import logger from "utils/log";
 export class CategoryComboD2Repository implements CategoryComboRepository {
     constructor(private api: D2Api) {}
 
-    async getAll(): Promise<CategoryCombo[]> {
-        return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [] });
+    async getAll(options: { ids?: Id[] }): Promise<CategoryCombo[]> {
+        return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [], ids: options.ids });
     }
 
     private async getAllByPages(options: {
         page: number;
         pageSize: number;
         categoryCombos: CategoryCombo[];
+        ids?: Id[];
     }): Promise<CategoryCombo[]> {
-        const { page, pageSize, categoryCombos } = options;
+        const { page, pageSize, categoryCombos, ids } = options;
 
-        const response = await this.getCategoryCombos({ page, pageSize });
+        const response = await this.getCategoryCombos({ page, pageSize, ids });
         const newRecords = [...categoryCombos, ...response.objects];
         const pager = response.pager;
         if (pager.page >= pager.pageCount) {
             return newRecords;
         } else {
-            return this.getAllByPages({ page: page + 1, pageSize, categoryCombos: newRecords });
+            return this.getAllByPages({ page: page + 1, pageSize, categoryCombos: newRecords, ids });
         }
     }
 
-    private async getCategoryCombos(options: { page: number; pageSize: number }) {
+    private async getCategoryCombos(options: { page: number; pageSize: number; ids?: Id[] }) {
         const response = await this.api.models.categoryCombos
             .get({
                 fields: {
@@ -39,6 +40,8 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                 },
                 page: options.page,
                 pageSize: options.pageSize,
+                // TODO: change to request in chunks when ids are provided
+                filter: options.ids ? { id: { in: options.ids } } : undefined,
             })
             .getData();
 

--- a/src/data/CategoryComboD2Repository.ts
+++ b/src/data/CategoryComboD2Repository.ts
@@ -1,14 +1,27 @@
 import _ from "lodash";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
-import { D2Api, Id } from "../types/d2-api";
+import { D2Api, Id, MetadataPick } from "../types/d2-api";
 import { CategoryComboRepository } from "../domain/repositories/CategoryComboRepository";
 import logger from "utils/log";
+import { promiseMap } from "./dhis2-utils";
 
 export class CategoryComboD2Repository implements CategoryComboRepository {
     constructor(private api: D2Api) {}
 
-    async getAll(options: { ids?: Id[] }): Promise<CategoryCombo[]> {
-        return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [], ids: options.ids });
+    async getAll(): Promise<CategoryCombo[]> {
+        return this.getAllByPages({ page: 1, pageSize: 100, categoryCombos: [] });
+    }
+
+    async getByIds(ids: Id[]): Promise<CategoryCombo[]> {
+        const allCombos = await promiseMap(_.chunk(ids, 100), async catComboIds => {
+            const response = await this.api.models.categoryCombos
+                .get({ fields: fields, paging: false, filter: { id: { in: catComboIds } } })
+                .getData();
+
+            return this.buildCategoryCombo(response.objects);
+        });
+
+        return allCombos.flat();
     }
 
     private async getAllByPages(options: {
@@ -31,21 +44,16 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
 
     private async getCategoryCombos(options: { page: number; pageSize: number; ids?: Id[] }) {
         const response = await this.api.models.categoryCombos
-            .get({
-                fields: {
-                    id: true,
-                    name: true,
-                    categories: { id: true, categoryOptions: { id: true, name: true } },
-                    categoryOptionCombos: { id: true, name: true, categoryOptions: { id: true, name: true } },
-                },
-                page: options.page,
-                pageSize: options.pageSize,
-                // TODO: change to request in chunks when ids are provided
-                filter: options.ids ? { id: { in: options.ids } } : undefined,
-            })
+            .get({ fields: fields, page: options.page, pageSize: options.pageSize })
             .getData();
 
-        const categoryCombos = _(response.objects)
+        const categoryCombos = this.buildCategoryCombo(response.objects);
+
+        return { objects: categoryCombos, pager: response.pager };
+    }
+
+    private buildCategoryCombo(catComboData: CategoryComboFields[]): CategoryCombo[] {
+        return _(catComboData)
             .map(catComboData => {
                 const categoryCombo = CategoryCombo.build({
                     id: catComboData.id,
@@ -73,8 +81,6 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
             })
             .compact()
             .value();
-
-        return { objects: categoryCombos, pager: response.pager };
     }
 }
 
@@ -133,3 +139,14 @@ export function reorderCocsByOptionIndex(catComboData: D2ApiCategoryCombo) {
         };
     });
 }
+
+const fields = {
+    id: true,
+    name: true,
+    categories: { id: true, categoryOptions: { id: true, name: true } },
+    categoryOptionCombos: { id: true, name: true, categoryOptions: { id: true, name: true } },
+} as const;
+
+type CategoryComboFields = MetadataPick<{
+    categoryCombos: { fields: typeof fields };
+}>["categoryCombos"][number];

--- a/src/data/CategoryComboD2Repository.ts
+++ b/src/data/CategoryComboD2Repository.ts
@@ -124,7 +124,7 @@ export function reorderCocsByOptionIndex(catComboData: D2ApiCategoryCombo) {
                     categoryIndex: categoryIndexByCocOptionPosition[inputPosition],
                     inputPosition,
                 }))
-                .sortBy(item => [item.categoryIndex, item.inputPosition])
+                .sortBy([item => item.categoryIndex, item => item.inputPosition])
                 .map(item => item.categoryOption)
                 .value(),
         };

--- a/src/data/CategoryComboD2Repository.ts
+++ b/src/data/CategoryComboD2Repository.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 import { D2Api, Id } from "../types/d2-api";
 import { CategoryComboRepository } from "../domain/repositories/CategoryComboRepository";
-import { fixCategoryOptionOrder, mapCategoryOptionIdToCategoryIndex } from "data/utils/cocs";
+import logger from "utils/log";
 
 export class CategoryComboD2Repository implements CategoryComboRepository {
     constructor(private api: D2Api) {}
@@ -54,7 +54,7 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
                             name: optData.name,
                         })),
                     })),
-                    categoryOptionCombos: this.reorderCategoryOptionCombos(catComboData),
+                    categoryOptionCombos: reorderCocsByOptionIndex(catComboData),
                 });
 
                 if (categoryCombo.isError()) {
@@ -73,16 +73,9 @@ export class CategoryComboD2Repository implements CategoryComboRepository {
 
         return { objects: categoryCombos, pager: response.pager };
     }
-
-    private reorderCategoryOptionCombos(catComboData: D2ApiCategoryCombo) {
-        return catComboData.categoryOptionCombos.map(categoryOptionCombo => {
-            const indexesByCategoryOptionId = mapCategoryOptionIdToCategoryIndex(catComboData);
-            return fixCategoryOptionOrder(categoryOptionCombo, indexesByCategoryOptionId);
-        });
-    }
 }
 
-type D2ApiCategoryCombo = {
+export type D2ApiCategoryCombo = {
     id: Id;
     categories: Array<{ id: Id; categoryOptions: Array<{ id: Id; name: string }> }>;
     categoryOptionCombos: Array<{
@@ -91,3 +84,49 @@ type D2ApiCategoryCombo = {
         categoryOptions: Array<{ id: Id; name: string }>;
     }>;
 };
+
+export function reorderCocsByOptionIndex(catComboData: D2ApiCategoryCombo) {
+    const categoryIndexesByOptionId = _(catComboData.categories)
+        .flatMap((category, categoryIndex) =>
+            category.categoryOptions.map(categoryOption => [categoryOption.id, categoryIndex] as const)
+        )
+        .groupBy(([categoryOptionId]) => categoryOptionId)
+        .mapValues(entries => entries.map(([_, categoryIndex]) => categoryIndex).sort((a, b) => a - b))
+        .value();
+
+    return catComboData.categoryOptionCombos.map(categoryOptionCombo => {
+        const hasUnknownCategoryOption = categoryOptionCombo.categoryOptions.some(
+            categoryOption => !categoryIndexesByOptionId[categoryOption.id]
+        );
+
+        if (hasUnknownCategoryOption) {
+            logger.debug("Return an empty array as categoryOptions to avoid unsafely relying on its order.");
+            return { ...categoryOptionCombo, categoryOptions: [] };
+        }
+
+        const assignmentCountByOptionId = new Map<Id, number>();
+
+        const categoryIndexByCocOptionPosition = categoryOptionCombo.categoryOptions.map(categoryOption => {
+            const categoryIndexes = categoryIndexesByOptionId[categoryOption.id] ?? [];
+            const alreadyAssignedCount = assignmentCountByOptionId.get(categoryOption.id) ?? 0;
+            assignmentCountByOptionId.set(categoryOption.id, alreadyAssignedCount + 1);
+
+            if (categoryIndexes.length === 0) return Number.MAX_SAFE_INTEGER;
+
+            return categoryIndexes[Math.min(alreadyAssignedCount, categoryIndexes.length - 1)];
+        });
+
+        return {
+            ...categoryOptionCombo,
+            categoryOptions: _(categoryOptionCombo.categoryOptions)
+                .map((categoryOption, inputPosition) => ({
+                    categoryOption,
+                    categoryIndex: categoryIndexByCocOptionPosition[inputPosition],
+                    inputPosition,
+                }))
+                .sortBy(item => [item.categoryIndex, item.inputPosition])
+                .map(item => item.categoryOption)
+                .value(),
+        };
+    });
+}

--- a/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
+++ b/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
@@ -1,78 +1,31 @@
 import { Id } from "domain/entities/Base";
 import { CategoryOptionComboDeleteExporter } from "domain/repositories/CategoryOptionComboDeleteExporter";
 import { writeFileSync } from "fs";
+import _ from "lodash";
 import logger from "utils/log";
+import { deleteCategoryOptionComboBatchSqlTemplate } from "./CategoryOptionComboDeleteSqlTemplate";
+
+const renderDeleteCategoryOptionComboBatchSql = _.template(deleteCategoryOptionComboBatchSqlTemplate);
 
 export class CategoryOptionComboDeleteD2SqlExporter implements CategoryOptionComboDeleteExporter {
     constructor(private pathToFile: string) {}
 
     exportDeleteScript(cocIds: string[]): void {
-        const sqlQuery = this.createDeleteUnusedCategoryOptionCombosSQL(cocIds);
+        const sqlQuery = this.createDeleteUnusedCategoryOptionCombosSQL(cocIds, { batchSize: 500 });
         this.writeToDisk(sqlQuery);
     }
 
-    private createDeleteUnusedCategoryOptionCombosSQL(ids: Id[], batchSize: number = 500): string {
-        const batches = Array.from({ length: Math.ceil(ids.length / batchSize) }, (_, i) =>
-            ids.slice(i * batchSize, (i + 1) * batchSize)
-        );
+    private createDeleteUnusedCategoryOptionCombosSQL(ids: Id[], options: { batchSize: number }): string {
+        const { batchSize } = options;
+        const batches = _.chunk(ids, batchSize);
 
         const batchStatements = batches.map(batch => {
             const valuesClause = batch.map(uid => `('${uid}')`).join(",\n  ");
 
-            return `CREATE TEMP TABLE temp_uids_batch (uid VARCHAR(11));
-INSERT INTO temp_uids_batch (uid) VALUES
-  ${valuesClause};
-
-CREATE TEMP TABLE temp_ids_batch AS
-SELECT coc.categoryoptioncomboid
-FROM categoryoptioncombo coc
-INNER JOIN temp_uids_batch t ON t.uid = coc.uid
-WHERE NOT EXISTS (
-    SELECT 1 FROM datavalue dv 
-    WHERE dv.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalue dv 
-    WHERE dv.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalueaudit dva 
-    WHERE dva.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalueaudit dva 
-    WHERE dva.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM dataelementoperand deo 
-    WHERE deo.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM completedatasetregistration csdr 
-    WHERE csdr.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datadimensionitem ddi 
-    WHERE ddi.dataelementoperand_categoryoptioncomboid = coc.categoryoptioncomboid
-  );    
-
-
-DELETE FROM categoryoptioncombos_categoryoptions 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DELETE FROM categorycombos_optioncombos 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DELETE FROM categoryoptioncombo 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DROP TABLE temp_uids_batch;
-DROP TABLE temp_ids_batch;
-
-`;
+            return renderDeleteCategoryOptionComboBatchSql({ valuesClause });
         });
 
-        return `BEGIN;${batchStatements.join("\n")}COMMIT;`.trim();
+        return ["BEGIN;", ...batchStatements, "COMMIT;"].join("\n");
     }
 
     private writeToDisk(sqlScript: string): void {

--- a/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
+++ b/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
@@ -1,18 +1,14 @@
 import { Id } from "domain/entities/Base";
 import { CategoryOptionComboDeleteExporter } from "domain/repositories/CategoryOptionComboDeleteExporter";
-import { writeFileSync } from "fs";
 import _ from "lodash";
-import logger from "utils/log";
 import { deleteCategoryOptionComboBatchSqlTemplate } from "./CategoryOptionComboDeleteSqlTemplate";
 
 const renderDeleteCategoryOptionComboBatchSql = _.template(deleteCategoryOptionComboBatchSqlTemplate);
 
 export class CategoryOptionComboDeleteD2SqlExporter implements CategoryOptionComboDeleteExporter {
-    constructor(private pathToFile: string) {}
-
-    exportDeleteScript(cocIds: string[]): void {
+    exportDeleteScript(cocIds: Id[]): string {
         const sqlQuery = this.createDeleteUnusedCategoryOptionCombosSQL(cocIds, { batchSize: 500 });
-        this.writeToDisk(sqlQuery);
+        return sqlQuery;
     }
 
     private createDeleteUnusedCategoryOptionCombosSQL(ids: Id[], options: { batchSize: number }): string {
@@ -26,12 +22,5 @@ export class CategoryOptionComboDeleteD2SqlExporter implements CategoryOptionCom
         });
 
         return ["BEGIN;", ...batchStatements, "COMMIT;"].join("\n");
-    }
-
-    private writeToDisk(sqlScript: string): void {
-        const fileName = `${this.pathToFile}.sql`;
-        writeFileSync(fileName, sqlScript);
-        logger.info(`SQL generated: ${fileName}`);
-        logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
     }
 }

--- a/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
+++ b/src/data/CategoryOptionComboDeleteD2SqlExporter.ts
@@ -1,0 +1,84 @@
+import { Id } from "domain/entities/Base";
+import { CategoryOptionComboDeleteExporter } from "domain/repositories/CategoryOptionComboDeleteExporter";
+import { writeFileSync } from "fs";
+import logger from "utils/log";
+
+export class CategoryOptionComboDeleteD2SqlExporter implements CategoryOptionComboDeleteExporter {
+    constructor(private pathToFile: string) {}
+
+    exportDeleteScript(cocIds: string[]): void {
+        const sqlQuery = this.createDeleteUnusedCategoryOptionCombosSQL(cocIds);
+        this.writeToDisk(sqlQuery);
+    }
+
+    private createDeleteUnusedCategoryOptionCombosSQL(ids: Id[], batchSize: number = 500): string {
+        const batches = Array.from({ length: Math.ceil(ids.length / batchSize) }, (_, i) =>
+            ids.slice(i * batchSize, (i + 1) * batchSize)
+        );
+
+        const batchStatements = batches.map(batch => {
+            const valuesClause = batch.map(uid => `('${uid}')`).join(",\n  ");
+
+            return `CREATE TEMP TABLE temp_uids_batch (uid VARCHAR(11));
+INSERT INTO temp_uids_batch (uid) VALUES
+  ${valuesClause};
+
+CREATE TEMP TABLE temp_ids_batch AS
+SELECT coc.categoryoptioncomboid
+FROM categoryoptioncombo coc
+INNER JOIN temp_uids_batch t ON t.uid = coc.uid
+WHERE NOT EXISTS (
+    SELECT 1 FROM datavalue dv 
+    WHERE dv.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalue dv 
+    WHERE dv.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva 
+    WHERE dva.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva 
+    WHERE dva.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM dataelementoperand deo 
+    WHERE deo.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM completedatasetregistration csdr 
+    WHERE csdr.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datadimensionitem ddi 
+    WHERE ddi.dataelementoperand_categoryoptioncomboid = coc.categoryoptioncomboid
+  );    
+
+
+DELETE FROM categoryoptioncombos_categoryoptions 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categorycombos_optioncombos 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categoryoptioncombo 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DROP TABLE temp_uids_batch;
+DROP TABLE temp_ids_batch;
+
+`;
+        });
+
+        return `BEGIN;${batchStatements.join("\n")}COMMIT;`.trim();
+    }
+
+    private writeToDisk(sqlScript: string): void {
+        const fileName = `${this.pathToFile}.sql`;
+        writeFileSync(fileName, sqlScript);
+        logger.info(`SQL generated: ${fileName}`);
+        logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
+    }
+}

--- a/src/data/CategoryOptionComboDeleteSqlTemplate.ts
+++ b/src/data/CategoryOptionComboDeleteSqlTemplate.ts
@@ -1,0 +1,48 @@
+export const deleteCategoryOptionComboBatchSqlTemplate = `CREATE TEMP TABLE temp_uids_batch (uid VARCHAR(11));
+INSERT INTO temp_uids_batch (uid) VALUES
+  <%= valuesClause %>;
+
+CREATE TEMP TABLE temp_ids_batch AS
+SELECT coc.categoryoptioncomboid
+FROM categoryoptioncombo coc
+INNER JOIN temp_uids_batch t ON t.uid = coc.uid
+WHERE NOT EXISTS (
+    SELECT 1 FROM datavalue dv
+    WHERE dv.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalue dv
+    WHERE dv.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva
+    WHERE dva.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva
+    WHERE dva.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM dataelementoperand deo
+    WHERE deo.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM completedatasetregistration csdr
+    WHERE csdr.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datadimensionitem ddi
+    WHERE ddi.dataelementoperand_categoryoptioncomboid = coc.categoryoptioncomboid
+  );
+
+DELETE FROM categoryoptioncombos_categoryoptions
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categorycombos_optioncombos
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categoryoptioncombo
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DROP TABLE temp_uids_batch;
+DROP TABLE temp_ids_batch;`;

--- a/src/data/RegeneratedCocD2Repository.ts
+++ b/src/data/RegeneratedCocD2Repository.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { D2Api, MetadataResponse } from "types/d2-api";
 import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
 import { Stats } from "domain/entities/Stats";
@@ -35,7 +36,10 @@ export class RegeneratedCocD2Repository implements RegeneratedCocRepository {
                         id: cocToSave.id,
                         name: cocToSave.name,
                         categoryCombo: { id: cocToSave.categoryCombo.id },
-                        categoryOptions: cocToSave.categoryOptions.map(co => ({ id: co.id })),
+                        categoryOptions: _(cocToSave.categoryOptions)
+                            .map(co => ({ id: co.id }))
+                            .uniqBy(x => x.id)
+                            .value(),
                     };
                 });
 

--- a/src/domain/repositories/CategoryComboD2Repository.spec.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.spec.ts
@@ -226,5 +226,32 @@ describe("CategoryComboD2Repository", () => {
                 { id: "NwnHnLEHuB7", name: "psycho-social" },
             ]);
         });
+
+        it("should sort by numeric categoryIndex and not lexicographically", () => {
+            const categoryCount = 11;
+            const categoryOptions = Array.from({ length: categoryCount }, (_, index) => ({
+                id: `opt${index}`,
+                name: `Option ${index}`,
+            }));
+
+            const catComboData: D2ApiCategoryCombo = {
+                id: "numeric-sort",
+                categories: categoryOptions.map((categoryOption, index) => ({
+                    id: `cat${index}`,
+                    categoryOptions: [categoryOption],
+                })),
+                categoryOptionCombos: [
+                    {
+                        id: "coc1",
+                        name: "numeric sort combo",
+                        categoryOptions: [...categoryOptions].reverse(),
+                    },
+                ],
+            };
+
+            const result = callReorderCategoryOptionCombos(catComboData);
+
+            expect(result[0]?.categoryOptions).toEqual(categoryOptions);
+        });
     });
 });

--- a/src/domain/repositories/CategoryComboD2Repository.spec.ts
+++ b/src/domain/repositories/CategoryComboD2Repository.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import { D2ApiCategoryCombo, reorderCocsByOptionIndex } from "../../data/CategoryComboD2Repository";
+
+describe("CategoryComboD2Repository", () => {
+    describe("reorderCategoryOptionCombos", () => {
+        const callReorderCategoryOptionCombos = (catComboData: D2ApiCategoryCombo) =>
+            reorderCocsByOptionIndex(catComboData);
+
+        it("should sort categoryOptions by category index when same option ID appears in multiple categories", () => {
+            const catComboData = {
+                id: "mMSl1dvxldo",
+                categories: [
+                    {
+                        id: "FYEU6t6pWY5",
+                        categoryOptions: [
+                            { id: "ApdutgFLjFX", name: "Conditional Cash" },
+                            { id: "Mf3sEqeY5MH", name: "Unconditional cash" },
+                            { id: "vyAxdvzFaAe", name: "Voucher" },
+                        ],
+                    },
+                    {
+                        id: "DHJ9e2i6GWQ",
+                        categoryOptions: [
+                            { id: "V3jZRcgMtVi", name: "IDP" },
+                            { id: "GqXI6derQVz", name: "Refugee" },
+                            { id: "rEqSna3GejM", name: "Host Community" },
+                            { id: "BNU3TNK0GXG", name: "Returnee" },
+                            { id: "bvFA7fsiN3T", name: "Not affected by displacement" },
+                            { id: "UFYWqMjLnn7", name: "Other" },
+                            { id: "fm1NzqBW6iU", name: "Conflict-affected but not displaced" },
+                        ],
+                    },
+                    {
+                        id: "eZ62z9CW6Tk",
+                        categoryOptions: [
+                            { id: "JDLJUK8KPvr", name: "Female" },
+                            { id: "cUqVhaqTJjj", name: "Male" },
+                        ],
+                    },
+                    {
+                        id: "OE9bPocwkPI",
+                        categoryOptions: [
+                            { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" },
+                            { id: "J2nHmx9G3JA", name: "Permanent Shelter" },
+                            { id: "EM36FglqBKj", name: "School Infrastructure" },
+                            { id: "kfP94NKZcUf", name: "Standalone" },
+                            { id: "UFYWqMjLnn7", name: "Other" },
+                        ],
+                    },
+                ],
+                categoryOptionCombos: [
+                    {
+                        id: "S6El1qcKMZd",
+                        name: "Conditional Cash, Other, Female, Temp/Transitional Shelter",
+                        categoryOptions: [
+                            { id: "ApdutgFLjFX", name: "Conditional Cash" }, // cat 0
+                            { id: "UFYWqMjLnn7", name: "Other" }, // cat 1
+                            { id: "JDLJUK8KPvr", name: "Female" }, // cat 2
+                            { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" }, // cat 3
+                        ],
+                    },
+                ],
+            };
+
+            const result = callReorderCategoryOptionCombos(catComboData);
+
+            expect(result[0]?.categoryOptions).toEqual([
+                { id: "ApdutgFLjFX", name: "Conditional Cash" }, // cat 0
+                { id: "UFYWqMjLnn7", name: "Other" }, // cat 1
+                { id: "JDLJUK8KPvr", name: "Female" }, // cat 2
+                { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" }, // cat 3
+            ]);
+        });
+
+        it("should correctly sort when options are provided in wrong order", () => {
+            const catComboData = {
+                id: "mMSl1dvxldo",
+                categories: [
+                    {
+                        id: "FYEU6t6pWY5",
+                        categoryOptions: [
+                            { id: "ApdutgFLjFX", name: "Conditional Cash" },
+                            { id: "Mf3sEqeY5MH", name: "Unconditional cash" },
+                        ],
+                    },
+                    {
+                        id: "DHJ9e2i6GWQ",
+                        categoryOptions: [{ id: "UFYWqMjLnn7", name: "Other" }],
+                    },
+                    {
+                        id: "eZ62z9CW6Tk",
+                        categoryOptions: [
+                            { id: "JDLJUK8KPvr", name: "Female" },
+                            { id: "cUqVhaqTJjj", name: "Male" },
+                        ],
+                    },
+                    {
+                        id: "OE9bPocwkPI",
+                        categoryOptions: [
+                            { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" },
+                            { id: "UFYWqMjLnn7", name: "Other" },
+                        ],
+                    },
+                ],
+                categoryOptionCombos: [
+                    {
+                        id: "S6El1qcKMZd",
+                        name: "Conditional Cash, Other, Female, Temp/Transitional Shelter",
+                        // Input: wrong order
+                        categoryOptions: [
+                            { id: "JDLJUK8KPvr", name: "Female" }, // cat 2
+                            { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" }, // cat 3
+                            { id: "ApdutgFLjFX", name: "Conditional Cash" }, // cat 0
+                            { id: "UFYWqMjLnn7", name: "Other" }, // cat 1
+                        ],
+                    },
+                ],
+            };
+
+            const result = callReorderCategoryOptionCombos(catComboData);
+
+            expect(result[0]?.categoryOptions).toEqual([
+                { id: "ApdutgFLjFX", name: "Conditional Cash" }, // cat 0
+                { id: "UFYWqMjLnn7", name: "Other" }, // cat 1
+                { id: "JDLJUK8KPvr", name: "Female" }, // cat 2
+                { id: "oDcGlG3YtOW", name: "Temp/Transitional Shelter" }, // cat 3
+            ]);
+        });
+
+        it("should return empty categoryOptions when there are missing options", () => {
+            const catComboData = {
+                id: "testCatCombo",
+                categories: [
+                    {
+                        id: "cat1",
+                        categoryOptions: [{ id: "opt1", name: "Option 1" }],
+                    },
+                ],
+                categoryOptionCombos: [
+                    {
+                        id: "coc1",
+                        name: "Test COC",
+                        categoryOptions: [
+                            { id: "opt1", name: "Option 1" },
+                            { id: "nonExistent", name: "Non Existent" },
+                        ],
+                    },
+                ],
+            };
+
+            const result = callReorderCategoryOptionCombos(catComboData);
+
+            expect(result[0]?.categoryOptions).toEqual([]);
+        });
+
+        it("should reorder cocs when categoryOptions order is wrong and options are duplicated across categories", () => {
+            const catComboData = {
+                name: "ComboDup",
+                categories: [
+                    {
+                        name: "CatDup1",
+                        categoryOptions: [
+                            {
+                                name: "school management",
+                                id: "dGtkPCDfqKJ",
+                            },
+                            {
+                                name: "Male",
+                                id: "cUqVhaqTJjj",
+                            },
+                        ],
+                        id: "xTTHxOe4ogD",
+                    },
+                    {
+                        name: "CatDup2",
+                        categoryOptions: [
+                            {
+                                name: "psycho-social",
+                                id: "NwnHnLEHuB7",
+                            },
+                            {
+                                name: "workshop",
+                                id: "pOLXvLHNnEm",
+                            },
+                        ],
+                        id: "AK0tGV68BYS",
+                    },
+                    {
+                        name: "CatDup3",
+                        categoryOptions: [
+                            {
+                                name: "psycho-social",
+                                id: "NwnHnLEHuB7",
+                            },
+                            {
+                                name: "school management",
+                                id: "dGtkPCDfqKJ",
+                            },
+                        ],
+                        id: "QsSV5GB535K",
+                    },
+                ],
+                id: "djIjuwzmmhe",
+                categoryOptionCombos: [
+                    {
+                        name: "school management, psycho-social, school management",
+                        categoryOptions: [
+                            {
+                                name: "psycho-social",
+                                id: "NwnHnLEHuB7",
+                            },
+                            {
+                                name: "school management",
+                                id: "dGtkPCDfqKJ",
+                            },
+                        ],
+                        id: "joTLqFolI1w",
+                    },
+                ],
+            };
+
+            const result = callReorderCategoryOptionCombos(catComboData);
+
+            expect(result[0]?.categoryOptions).toEqual([
+                { id: "dGtkPCDfqKJ", name: "school management" },
+                { id: "NwnHnLEHuB7", name: "psycho-social" },
+            ]);
+        });
+    });
+});

--- a/src/domain/repositories/CategoryComboRepository.ts
+++ b/src/domain/repositories/CategoryComboRepository.ts
@@ -2,5 +2,6 @@ import { Id } from "domain/entities/Base";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 
 export interface CategoryComboRepository {
-    getAll(options: { ids?: Id[] }): Promise<CategoryCombo[]>;
+    getAll(): Promise<CategoryCombo[]>;
+    getByIds(ids: Id[]): Promise<CategoryCombo[]>;
 }

--- a/src/domain/repositories/CategoryComboRepository.ts
+++ b/src/domain/repositories/CategoryComboRepository.ts
@@ -1,5 +1,6 @@
+import { Id } from "domain/entities/Base";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 
 export interface CategoryComboRepository {
-    getAll(): Promise<CategoryCombo[]>;
+    getAll(options: { ids?: Id[] }): Promise<CategoryCombo[]>;
 }

--- a/src/domain/repositories/CategoryOptionComboDeleteExporter.ts
+++ b/src/domain/repositories/CategoryOptionComboDeleteExporter.ts
@@ -1,0 +1,5 @@
+import { Id } from "domain/entities/Base";
+
+export interface CategoryOptionComboDeleteExporter {
+    exportDeleteScript(cocIds: Id[]): void;
+}

--- a/src/domain/repositories/CategoryOptionComboDeleteExporter.ts
+++ b/src/domain/repositories/CategoryOptionComboDeleteExporter.ts
@@ -1,5 +1,5 @@
 import { Id } from "domain/entities/Base";
 
 export interface CategoryOptionComboDeleteExporter {
-    exportDeleteScript(cocIds: Id[]): void;
+    exportDeleteScript(cocIds: Id[]): string;
 }

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -83,9 +83,10 @@ export class RegenerateCocsUseCase {
 
     private async getCategoryCombos(options: UseCaseArgs): Promise<CategoryCombo[]> {
         logger.info("Fetching categoryOptionCombos...");
-        const categoryCombos = await this.options.categoryComboRepository.getAll({
-            ids: options.catCombosIds,
-        });
+        const categoryCombos =
+            options.catCombosIds && options.catCombosIds.length > 0
+                ? await this.options.categoryComboRepository.getByIds(options.catCombosIds)
+                : await this.options.categoryComboRepository.getAll();
         logger.info(`${categoryCombos.length} categoryOptionCombos found.`);
         return categoryCombos;
     }

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -102,7 +102,7 @@ export class RegenerateCocsUseCase {
             (combination): { regeneratedCoc: RegeneratedCoc; toBeSaved: boolean } => {
                 const combinationName = combination.map(opt => opt.name).join(", ");
                 const combinationKey = this.getCategoryOptionComboKey(combination);
-                const categoryComboId = getUid(combinationKey, categoryCombo.id);
+                const categoryOptionComboId = getUid(combinationKey, categoryCombo.id);
 
                 const existingCategoryOptionCombo = existingCategoryOptionCombosByKey.get(combinationKey);
 
@@ -122,7 +122,7 @@ export class RegenerateCocsUseCase {
 
                 return {
                     regeneratedCoc: RegeneratedCoc.create({
-                        id: categoryComboId,
+                        id: categoryOptionComboId,
                         name: combinationName,
                         categoryCombo: { id: categoryCombo.id },
                         categoryOptions: combination,

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -24,7 +24,7 @@ export class RegenerateCocsUseCase {
 
         await this.saveCocs(categoryComboWithGeneratedCocs, options);
         if (options.deleteCocs) {
-            await this.deleteCocs(categoryComboWithGeneratedCocs, options);
+            await this.deleteCocs(categoryComboWithGeneratedCocs);
         }
 
         return { categoryCombos: categoryComboWithGeneratedCocs };
@@ -34,7 +34,10 @@ export class RegenerateCocsUseCase {
         categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"],
         options: UseCaseArgs
     ): Promise<Stats> {
-        const cocsToCreate = categoryComboWithGeneratedCocs.flatMap(item => item.categoryOptionCombos);
+        const cocsToCreate = _(categoryComboWithGeneratedCocs)
+            .flatMap(item => item.categoryOptionCombos)
+            .uniqBy(coc => coc.id)
+            .value();
         logger.info(`Saving ${cocsToCreate.length} categoryOptionCombos...`);
         const saveStats = await this.options.regeneratedCocRepository.save(cocsToCreate, {
             persist: options.persist,
@@ -45,16 +48,14 @@ export class RegenerateCocsUseCase {
     }
 
     private async deleteCocs(
-        categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"],
-        options: UseCaseArgs
+        categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"]
     ): Promise<Stats> {
-        const { deleteCocs } = options;
         const cocIdsToDelete = categoryComboWithGeneratedCocs.flatMap(item =>
             item.cocsToDelete.map(coc => coc.id)
         );
         logger.info(`Deleting ${cocIdsToDelete.length} categoryOptionCombos...`);
         const deleteStats = await this.options.regeneratedCocRepository.deleteByIds(cocIdsToDelete, {
-            persist: deleteCocs,
+            persist: true,
         });
         logger.info(`Finished: ${JSON.stringify(deleteStats, null, 2)}`);
         return deleteStats;
@@ -90,8 +91,9 @@ export class RegenerateCocsUseCase {
         const categoryOptionCombos = combinations.map(
             (combination): { regeneratedCoc: RegeneratedCoc; toBeSaved: boolean } => {
                 const combinationName = combination.map(opt => opt.name).join(", ");
-
                 const combinationKey = this.getCategoryOptionComboKey(combination);
+                const categoryComboId = getUid(combinationKey, categoryCombo.id);
+
                 const existingCategoryOptionCombo = existingCategoryOptionCombosByKey.get(combinationKey);
 
                 if (existingCategoryOptionCombo) {
@@ -110,7 +112,7 @@ export class RegenerateCocsUseCase {
 
                 return {
                     regeneratedCoc: RegeneratedCoc.create({
-                        id: getUid(combinationKey, categoryCombo.id),
+                        id: categoryComboId,
                         name: combinationName,
                         categoryCombo: { id: categoryCombo.id },
                         categoryOptions: combination,
@@ -169,6 +171,7 @@ export class RegenerateCocsUseCase {
     private getCategoryOptionComboKey(categoryOptions: NamedRef[]): string {
         return _(categoryOptions)
             .map(categoryOption => categoryOption.id)
+            .sort()
             .uniq()
             .join("|");
     }

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import logger from "utils/log";
 import { getUid } from "data/dhis2";
-import { NamedRef } from "domain/entities/Base";
+import { Id, NamedRef } from "domain/entities/Base";
 import { CategoryCombo } from "domain/entities/CategoryCombo";
 import { CategoryComboRepository } from "domain/repositories/CategoryComboRepository";
 import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
@@ -20,7 +20,7 @@ export class RegenerateCocsUseCase {
     ) {}
 
     async execute(options: UseCaseArgs): Promise<RegenerateCocsUseCaseResult> {
-        const categoryCombos = await this.getCategoryCombos();
+        const categoryCombos = await this.getCategoryCombos(options);
         const categoryComboWithGeneratedCocs = categoryCombos.map(categoryCombo =>
             this.generateCombinationsFromCategoryCombo(categoryCombo)
         );
@@ -81,9 +81,11 @@ export class RegenerateCocsUseCase {
         return deleteStats;
     }
 
-    private async getCategoryCombos(): Promise<CategoryCombo[]> {
+    private async getCategoryCombos(options: UseCaseArgs): Promise<CategoryCombo[]> {
         logger.info("Fetching categoryOptionCombos...");
-        const categoryCombos = await this.options.categoryComboRepository.getAll();
+        const categoryCombos = await this.options.categoryComboRepository.getAll({
+            ids: options.catCombosIds,
+        });
         logger.info(`${categoryCombos.length} categoryOptionCombos found.`);
         return categoryCombos;
     }
@@ -207,4 +209,9 @@ export type RegenerateCocsUseCaseResult = {
     sqlDeleteScript: Maybe<string>;
 };
 
-type UseCaseArgs = { deleteCocs: boolean; persist: boolean; generateSqlDeleteScript: boolean };
+type UseCaseArgs = {
+    catCombosIds: Maybe<Id[]>;
+    deleteCocs: boolean;
+    persist: boolean;
+    generateSqlDeleteScript: boolean;
+};

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -7,12 +7,14 @@ import { CategoryComboRepository } from "domain/repositories/CategoryComboReposi
 import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
 import { RegeneratedCocRepository } from "domain/repositories/RegeneratedCocRepository";
 import { Stats } from "domain/entities/Stats";
+import { CategoryOptionComboDeleteExporter } from "domain/repositories/CategoryOptionComboDeleteExporter";
 
 export class RegenerateCocsUseCase {
     constructor(
         private options: {
             categoryComboRepository: CategoryComboRepository;
             regeneratedCocRepository: RegeneratedCocRepository;
+            cocDeleteExporter: CategoryOptionComboDeleteExporter;
         }
     ) {}
 
@@ -23,8 +25,16 @@ export class RegenerateCocsUseCase {
         );
 
         await this.saveCocs(categoryComboWithGeneratedCocs, options);
+
         if (options.deleteCocs) {
             await this.deleteCocs(categoryComboWithGeneratedCocs);
+        }
+
+        if (options.generateSqlDeleteScript) {
+            const cocIdsToDelete = categoryComboWithGeneratedCocs.flatMap(item =>
+                item.cocsToDelete.map(coc => coc.id)
+            );
+            this.options.cocDeleteExporter.exportDeleteScript(cocIdsToDelete);
         }
 
         return { categoryCombos: categoryComboWithGeneratedCocs };
@@ -186,4 +196,4 @@ export type RegenerateCocsUseCaseResult = {
     }>;
 };
 
-type UseCaseArgs = { deleteCocs: boolean; persist: boolean };
+type UseCaseArgs = { deleteCocs: boolean; persist: boolean; generateSqlDeleteScript: boolean };

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -8,6 +8,7 @@ import { RegeneratedCoc } from "domain/entities/RegeneratedCoc";
 import { RegeneratedCocRepository } from "domain/repositories/RegeneratedCocRepository";
 import { Stats } from "domain/entities/Stats";
 import { CategoryOptionComboDeleteExporter } from "domain/repositories/CategoryOptionComboDeleteExporter";
+import { Maybe } from "utils/ts-utils";
 
 export class RegenerateCocsUseCase {
     constructor(
@@ -30,14 +31,23 @@ export class RegenerateCocsUseCase {
             await this.deleteCocs(categoryComboWithGeneratedCocs);
         }
 
-        if (options.generateSqlDeleteScript) {
-            const cocIdsToDelete = categoryComboWithGeneratedCocs.flatMap(item =>
-                item.cocsToDelete.map(coc => coc.id)
-            );
-            this.options.cocDeleteExporter.exportDeleteScript(cocIdsToDelete);
-        }
+        return {
+            categoryCombos: categoryComboWithGeneratedCocs,
+            sqlDeleteScript: this.buildSqlDeleteScript(options, categoryComboWithGeneratedCocs),
+        };
+    }
 
-        return { categoryCombos: categoryComboWithGeneratedCocs };
+    private buildSqlDeleteScript(
+        options: UseCaseArgs,
+        categoryComboWithGeneratedCocs: RegenerateCocsUseCaseResult["categoryCombos"]
+    ): Maybe<string> {
+        const { generateSqlDeleteScript } = options;
+        if (!generateSqlDeleteScript) return undefined;
+
+        const cocIdsToDelete = categoryComboWithGeneratedCocs.flatMap(item =>
+            item.cocsToDelete.map(coc => coc.id)
+        );
+        return this.options.cocDeleteExporter.exportDeleteScript(cocIdsToDelete);
     }
 
     private async saveCocs(
@@ -194,6 +204,7 @@ export type RegenerateCocsUseCaseResult = {
         allCategoryOptionCombos: RegeneratedCoc[];
         cocsToDelete: RegeneratedCoc[];
     }>;
+    sqlDeleteScript: Maybe<string>;
 };
 
 type UseCaseArgs = { deleteCocs: boolean; persist: boolean; generateSqlDeleteScript: boolean };

--- a/src/domain/usecases/RegenerateCocsUseCase.ts
+++ b/src/domain/usecases/RegenerateCocsUseCase.ts
@@ -23,7 +23,9 @@ export class RegenerateCocsUseCase {
         );
 
         await this.saveCocs(categoryComboWithGeneratedCocs, options);
-        await this.deleteCocs(categoryComboWithGeneratedCocs, options);
+        if (options.deleteCocs) {
+            await this.deleteCocs(categoryComboWithGeneratedCocs, options);
+        }
 
         return { categoryCombos: categoryComboWithGeneratedCocs };
     }

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -25,9 +25,9 @@ export const regenerateCocsCmd = command({
             long: "generate-sql-delete-script",
             description: "generate a SQL script to delete obsolete categoryOptionCombos (default: false)",
         }),
-        catCombosIds: option({
+        categoryComboIds: option({
             type: optional(StringsSeparatedByCommas),
-            long: "cat-combos-ids",
+            long: "category-combo-ids",
             description:
                 "comma-separated list of categoryCombo IDs. If not provided, all categoryCombos will be regenerated.",
         }),
@@ -51,7 +51,7 @@ export const regenerateCocsCmd = command({
                 generateSqlDeleteScript: args.generateSqlDeleteScript,
                 persist: args.persist,
                 deleteCocs: args.deleteCocs,
-                catCombosIds: args.catCombosIds,
+                catCombosIds: args.categoryComboIds,
             });
             generateJsonReport(response.categoryCombos);
             if (response.sqlDeleteScript) {
@@ -87,5 +87,5 @@ function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categor
 function writeSqlScriptToDisk(sqlScript: string, fileName: string): void {
     writeFileSync(fileName, sqlScript);
     logger.info(`SQL generated: ${fileName}`);
-    logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
+    logger.info(`You can execute the sql with d2-docker: d2-docker run-sql -i [IMAGE_NAME] ${fileName}`);
 }

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -6,6 +6,7 @@ import { writeFileSync } from "fs";
 import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
 import logger from "utils/log";
 import { getCurrentTime } from "utils/date";
+import { CategoryOptionComboDeleteD2SqlExporter } from "data/CategoryOptionComboDeleteD2SqlExporter";
 
 export const regenerateCocsCmd = command({
     name: "regenerate",
@@ -26,17 +27,28 @@ export const regenerateCocsCmd = command({
         }),
     },
     handler: async args => {
+        const currentTime = getCurrentTime();
         const api = getD2ApiFromArgs(args);
         const categoryComboRepository = new CategoryComboD2Repository(api);
         const regeneratedCocRepository = new RegeneratedCocD2Repository(api);
-        const useCase = new RegenerateCocsUseCase({ categoryComboRepository, regeneratedCocRepository });
+
+        const cocDeleteExporter = new CategoryOptionComboDeleteD2SqlExporter(
+            `delete-category-option-combos-${currentTime}.sql`
+        );
+
+        const useCase = new RegenerateCocsUseCase({
+            cocDeleteExporter,
+            categoryComboRepository,
+            regeneratedCocRepository,
+        });
 
         try {
-            const response = await useCase.execute({ persist: args.persist, deleteCocs: args.deleteCocs });
+            const response = await useCase.execute({
+                generateSqlDeleteScript: args.generateSqlDeleteScript,
+                persist: args.persist,
+                deleteCocs: args.deleteCocs,
+            });
             generateJsonReport(response.categoryCombos);
-            if (args.generateSqlDeleteScript) {
-                generateSqlDeleteScript(response.categoryCombos);
-            }
         } catch (error) {
             logger.error(`Error regenerating categoryOptionCombos: ${JSON.stringify(error, null, 2)}`);
             process.exit(1);
@@ -59,82 +71,4 @@ function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categor
 
     writeFileSync(fileName, JSON.stringify(jsonReport, null, 2));
     logger.info(`Report generated: ${fileName}`);
-}
-
-const createDeleteUnusedCategoryOptionCombosSQL = (
-    uids: ReadonlyArray<string>,
-    batchSize: number = 500
-): string => {
-    const batches = Array.from({ length: Math.ceil(uids.length / batchSize) }, (_, i) =>
-        uids.slice(i * batchSize, (i + 1) * batchSize)
-    );
-
-    const batchStatements = batches.map(batch => {
-        const valuesClause = batch.map(uid => `('${uid}')`).join(",\n  ");
-
-        return `CREATE TEMP TABLE temp_uids_batch (uid VARCHAR(11));
-INSERT INTO temp_uids_batch (uid) VALUES
-  ${valuesClause};
-
-CREATE TEMP TABLE temp_ids_batch AS
-SELECT coc.categoryoptioncomboid
-FROM categoryoptioncombo coc
-INNER JOIN temp_uids_batch t ON t.uid = coc.uid
-WHERE NOT EXISTS (
-    SELECT 1 FROM datavalue dv 
-    WHERE dv.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalue dv 
-    WHERE dv.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalueaudit dva 
-    WHERE dva.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datavalueaudit dva 
-    WHERE dva.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM dataelementoperand deo 
-    WHERE deo.categoryoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM completedatasetregistration csdr 
-    WHERE csdr.attributeoptioncomboid = coc.categoryoptioncomboid
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM datadimensionitem ddi 
-    WHERE ddi.dataelementoperand_categoryoptioncomboid = coc.categoryoptioncomboid
-  );    
-
-
-DELETE FROM categoryoptioncombos_categoryoptions 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DELETE FROM categorycombos_optioncombos 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DELETE FROM categoryoptioncombo 
-WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
-
-DROP TABLE temp_uids_batch;
-DROP TABLE temp_ids_batch;
-
-`;
-    });
-
-    return `BEGIN;${batchStatements.join("\n")}COMMIT;`.trim();
-};
-
-function generateSqlDeleteScript(categoryCombos: RegenerateCocsUseCaseResult["categoryCombos"]): void {
-    const allIds = categoryCombos.flatMap(catCombo => catCombo.cocsToDelete.map(coc => coc.id));
-    const sqlScript = createDeleteUnusedCategoryOptionCombosSQL(allIds);
-
-    const currentTime = getCurrentTime();
-    const fileName = `delete-category-option-combos-${currentTime}.sql`;
-    writeFileSync(fileName, sqlScript);
-    logger.info(`SQL generated: ${fileName}`);
-    logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
 }

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -32,9 +32,7 @@ export const regenerateCocsCmd = command({
         const categoryComboRepository = new CategoryComboD2Repository(api);
         const regeneratedCocRepository = new RegeneratedCocD2Repository(api);
 
-        const cocDeleteExporter = new CategoryOptionComboDeleteD2SqlExporter(
-            `delete-category-option-combos-${currentTime}.sql`
-        );
+        const cocDeleteExporter = new CategoryOptionComboDeleteD2SqlExporter();
 
         const useCase = new RegenerateCocsUseCase({
             cocDeleteExporter,
@@ -49,6 +47,12 @@ export const regenerateCocsCmd = command({
                 deleteCocs: args.deleteCocs,
             });
             generateJsonReport(response.categoryCombos);
+            if (response.sqlDeleteScript) {
+                writeSqlScriptToDisk(
+                    response.sqlDeleteScript,
+                    `delete-category-option-combos-${currentTime}.sql`
+                );
+            }
         } catch (error) {
             logger.error(`Error regenerating categoryOptionCombos: ${JSON.stringify(error, null, 2)}`);
             process.exit(1);
@@ -71,4 +75,10 @@ function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categor
 
     writeFileSync(fileName, JSON.stringify(jsonReport, null, 2));
     logger.info(`Report generated: ${fileName}`);
+}
+
+function writeSqlScriptToDisk(sqlScript: string, fileName: string): void {
+    writeFileSync(fileName, sqlScript);
+    logger.info(`SQL generated: ${fileName}`);
+    logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
 }

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -1,9 +1,9 @@
-import { command, flag } from "cmd-ts";
+import { command, flag, option, optional } from "cmd-ts";
 import { RegeneratedCocD2Repository } from "data/RegeneratedCocD2Repository";
 import { CategoryComboD2Repository } from "data/CategoryComboD2Repository";
 import { RegenerateCocsUseCase, RegenerateCocsUseCaseResult } from "domain/usecases/RegenerateCocsUseCase";
 import { writeFileSync } from "fs";
-import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
+import { getApiUrlOptions, getD2ApiFromArgs, StringsSeparatedByCommas } from "scripts/common";
 import logger from "utils/log";
 import { getCurrentTime } from "utils/date";
 import { CategoryOptionComboDeleteD2SqlExporter } from "data/CategoryOptionComboDeleteD2SqlExporter";
@@ -25,6 +25,12 @@ export const regenerateCocsCmd = command({
             long: "generate-sql-delete-script",
             description: "generate a SQL script to delete obsolete categoryOptionCombos (default: false)",
         }),
+        catCombosIds: option({
+            type: optional(StringsSeparatedByCommas),
+            long: "cat-combos-ids",
+            description:
+                "comma-separated list of categoryCombo IDs. If not provided, all categoryCombos will be regenerated.",
+        }),
     },
     handler: async args => {
         const currentTime = getCurrentTime();
@@ -45,6 +51,7 @@ export const regenerateCocsCmd = command({
                 generateSqlDeleteScript: args.generateSqlDeleteScript,
                 persist: args.persist,
                 deleteCocs: args.deleteCocs,
+                catCombosIds: args.catCombosIds,
             });
             generateJsonReport(response.categoryCombos);
             if (response.sqlDeleteScript) {

--- a/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
+++ b/src/scripts/commands/category-option-combos/regenerateCocsCmd.ts
@@ -5,6 +5,7 @@ import { RegenerateCocsUseCase, RegenerateCocsUseCaseResult } from "domain/useca
 import { writeFileSync } from "fs";
 import { getApiUrlOptions, getD2ApiFromArgs } from "scripts/common";
 import logger from "utils/log";
+import { getCurrentTime } from "utils/date";
 
 export const regenerateCocsCmd = command({
     name: "regenerate",
@@ -19,6 +20,10 @@ export const regenerateCocsCmd = command({
             long: "delete-cocs",
             description: "delete obsolete categoryOptionCombos (default: false)",
         }),
+        generateSqlDeleteScript: flag({
+            long: "generate-sql-delete-script",
+            description: "generate a SQL script to delete obsolete categoryOptionCombos (default: false)",
+        }),
     },
     handler: async args => {
         const api = getD2ApiFromArgs(args);
@@ -29,6 +34,9 @@ export const regenerateCocsCmd = command({
         try {
             const response = await useCase.execute({ persist: args.persist, deleteCocs: args.deleteCocs });
             generateJsonReport(response.categoryCombos);
+            if (args.generateSqlDeleteScript) {
+                generateSqlDeleteScript(response.categoryCombos);
+            }
         } catch (error) {
             logger.error(`Error regenerating categoryOptionCombos: ${JSON.stringify(error, null, 2)}`);
             process.exit(1);
@@ -37,7 +45,7 @@ export const regenerateCocsCmd = command({
 });
 
 function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categoryCombos"]): void {
-    const currentTime = new Date().toISOString().replace(/[:.]/g, "-");
+    const currentTime = getCurrentTime();
     const fileName = `regenerated-category-option-combos-${currentTime}.json`;
 
     const jsonReport = categoryCombos.map(catCombo => ({
@@ -51,4 +59,82 @@ function generateJsonReport(categoryCombos: RegenerateCocsUseCaseResult["categor
 
     writeFileSync(fileName, JSON.stringify(jsonReport, null, 2));
     logger.info(`Report generated: ${fileName}`);
+}
+
+const createDeleteUnusedCategoryOptionCombosSQL = (
+    uids: ReadonlyArray<string>,
+    batchSize: number = 500
+): string => {
+    const batches = Array.from({ length: Math.ceil(uids.length / batchSize) }, (_, i) =>
+        uids.slice(i * batchSize, (i + 1) * batchSize)
+    );
+
+    const batchStatements = batches.map(batch => {
+        const valuesClause = batch.map(uid => `('${uid}')`).join(",\n  ");
+
+        return `CREATE TEMP TABLE temp_uids_batch (uid VARCHAR(11));
+INSERT INTO temp_uids_batch (uid) VALUES
+  ${valuesClause};
+
+CREATE TEMP TABLE temp_ids_batch AS
+SELECT coc.categoryoptioncomboid
+FROM categoryoptioncombo coc
+INNER JOIN temp_uids_batch t ON t.uid = coc.uid
+WHERE NOT EXISTS (
+    SELECT 1 FROM datavalue dv 
+    WHERE dv.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalue dv 
+    WHERE dv.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva 
+    WHERE dva.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datavalueaudit dva 
+    WHERE dva.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM dataelementoperand deo 
+    WHERE deo.categoryoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM completedatasetregistration csdr 
+    WHERE csdr.attributeoptioncomboid = coc.categoryoptioncomboid
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM datadimensionitem ddi 
+    WHERE ddi.dataelementoperand_categoryoptioncomboid = coc.categoryoptioncomboid
+  );    
+
+
+DELETE FROM categoryoptioncombos_categoryoptions 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categorycombos_optioncombos 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DELETE FROM categoryoptioncombo 
+WHERE categoryoptioncomboid IN (SELECT categoryoptioncomboid FROM temp_ids_batch);
+
+DROP TABLE temp_uids_batch;
+DROP TABLE temp_ids_batch;
+
+`;
+    });
+
+    return `BEGIN;${batchStatements.join("\n")}COMMIT;`.trim();
+};
+
+function generateSqlDeleteScript(categoryCombos: RegenerateCocsUseCaseResult["categoryCombos"]): void {
+    const allIds = categoryCombos.flatMap(catCombo => catCombo.cocsToDelete.map(coc => coc.id));
+    const sqlScript = createDeleteUnusedCategoryOptionCombosSQL(allIds);
+
+    const currentTime = getCurrentTime();
+    const fileName = `delete-category-option-combos-${currentTime}.sql`;
+    writeFileSync(fileName, sqlScript);
+    logger.info(`SQL generated: ${fileName}`);
+    logger.info(`You can execute the sql with d2-docker: d2-docker run-sql ${fileName}`);
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,3 @@
+export function getCurrentTime(): string {
+    return new Date().toISOString().replace(/[:.]/g, "-");
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/869btxm35

### :memo: Implementation

Generating a sql script for deleting categoryOptionCombos.

```shell
yarn start categoryOptionCombos regenerate \
    --url=https://play.im.dhis2.org/stable-2-40-10 \
    --auth="admin:district" \
     --generate-sql-delete-script
```

Before deleting a `categoryOptionCombo` the script checks for existing data in the `datavalue` and `datavalueaudit` tables. If you have thousands or millions of records, this process can be very slow. 

Adding an index to these tables improves performance significantly:

```sql
CREATE INDEX CONCURRENTLY idx_datavalue_catoptcombo ON datavalue(categoryoptioncomboid);
CREATE INDEX CONCURRENTLY idx_datavalue_attoptcombo ON datavalue(attributeoptioncomboid);
CREATE INDEX CONCURRENTLY idx_datavalueaudit_catoptcombo ON datavalueaudit(categoryoptioncomboid);
CREATE INDEX CONCURRENTLY idx_datavalueaudit_attoptcombo ON datavalueaudit(attributeoptioncomboid);
```

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

#869btxm35