### PR TITLE
Fix/disable users server freeze

### DIFF
--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -1,11 +1,14 @@
 import { D2Api } from "types/d2-api";
 import log from "utils/log";
 import _ from "lodash";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
 import { PermissionFixerUser } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUser";
 import { Async } from "domain/entities/Async";
 import { Method } from "@eyeseetea/d2-api/repositories/HttpClientRepository";
+
+const DISABLE_USERS_BATCH_SIZE = 50;
 
 export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     constructor(private api: D2Api) {}
@@ -35,30 +38,37 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
         });
     }
 
-    async disableUsers(userIds: string[]): Async<string> {
+    async disableUsers(userIds: string[]): Async<DisableUserResult[]> {
         log.info(`Disabling users by ids: ${userIds.join(",")}`);
 
-        const results = await Promise.all(
-            userIds.map(async userId => {
-                try {
-                    const response = await this.api
-                        .request<string>({
-                            // TEMPORAL. See https://github.com/EyeSeeTea/d2-api/pull/171
-                            method: "patch" as Method,
-                            url: `/41/users/${userId}`,
-                            headers: { "Content-Type": "application/json-patch+json" },
-                            data: [{ op: "replace", path: "/disabled", value: true }],
-                        })
-                        .getData();
+        const results: DisableUserResult[] = [];
 
-                    return { userId, status: "success", response };
-                } catch (error) {
-                    log.error(`Error disabling user ${userId}:` + error);
-                    return { userId, status: "error", error };
-                }
-            })
-        );
-        return JSON.stringify(results);
+        for (const userIdsBatch of _.chunk(userIds, DISABLE_USERS_BATCH_SIZE)) {
+            const batchResults = await Promise.all(
+                userIdsBatch.map(async (userId): Promise<DisableUserResult> => {
+                    try {
+                        const response = await this.api
+                            .request<string>({
+                                // TEMPORAL. See https://github.com/EyeSeeTea/d2-api/pull/171
+                                method: "patch" as Method,
+                                url: `/41/users/${userId}`,
+                                headers: { "Content-Type": "application/json-patch+json" },
+                                data: [{ op: "replace", path: "/disabled", value: true }],
+                            })
+                            .getData();
+
+                        return { userId, status: "success", response };
+                    } catch (error) {
+                        log.error(`Error disabling user ${userId}:` + error);
+                        return { userId, status: "error", error };
+                    }
+                })
+            );
+
+            results.push(...batchResults);
+        }
+
+        return results;
     }
 }
 

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult.ts
@@ -1,0 +1,8 @@
+export type DisableUserResultStatus = "success" | "error";
+
+export interface DisableUserResult {
+    userId: string;
+    status: DisableUserResultStatus;
+    response?: string;
+    error?: unknown;
+}

--- a/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
+++ b/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
@@ -1,6 +1,8 @@
 import { Async } from "domain/entities/Async";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 
 export interface TwoFactorUserRepository {
     getUsersNotInGroupIds(excludeUserGroupIds: string[]): Async<TwoFactorUser[]>;
+    disableUsers(userIds: string[]): Async<DisableUserResult[]>;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -124,9 +124,7 @@ export class RunTwoFactorReportUseCase {
                 const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
                 const batchResults = JSON.parse(batchResponse);
 
-                if (Array.isArray(batchResults)) {
-                    disableResults.push(...batchResults);
-                }
+                disableResults.push(...batchResults);
             } catch {
                 disableResults.push({
                     userId: "unknown",

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -91,12 +91,13 @@ export class RunTwoFactorReportUseCase {
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
             if (invalidTwoFactorUsers.length > 0) {
-                const disableResponse = await this.userRepository.disableUsers(
-                    invalidTwoFactorUsers.map(user => user.id)
+                const disableResponse = await this.disableUsersInBatches(
+                    invalidTwoFactorUsers.map(user => user.id),
+                    50
                 );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: JSON.stringify(disableResponse),
+                    disableUsersMessage: disableResponse,
                     report,
                 };
             } else {
@@ -113,6 +114,29 @@ export class RunTwoFactorReportUseCase {
             disableUsersMessage: "Disabled users action is not enabled.",
             report,
         };
+    }
+
+    private async disableUsersInBatches(userIds: string[], batchSize: number): Async<string> {
+        const disableResults: Array<{ userId: string; status: string; response?: string; error?: unknown }> = [];
+
+        for (const userIdsBatch of _.chunk(userIds, batchSize)) {
+            try {
+                const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
+                const batchResults = JSON.parse(batchResponse);
+
+                if (Array.isArray(batchResults)) {
+                    disableResults.push(...batchResults);
+                }
+            } catch {
+                disableResults.push({
+                    userId: "unknown",
+                    status: "error",
+                    error: `Invalid disable users response for batch: ${userIdsBatch.join(",")}`,
+                });
+            }
+        }
+
+        return JSON.stringify(disableResults);
     }
 }
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -1,8 +1,5 @@
 import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
-import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
-import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
-import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
 import { TwoFactorReportRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorReportRepository";

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -1,19 +1,22 @@
-import _ from "lodash";
-import { TwoFactorUserD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
+import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
 import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
 import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
 import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
+import { TwoFactorReportRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorReportRepository";
+import { TwoFactorConfigRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorConfigRepository";
+import { UserMonitoringProgramRepository } from "domain/repositories/user-monitoring/common/UserMonitoringProgramRepository";
 
 type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 
 export class RunTwoFactorReportUseCase {
     constructor(
-        private userRepository: TwoFactorUserD2Repository,
-        private reportRepository: TwoFactorReportD2Repository,
-        private configRepository: TwoFactorConfigD2Repository,
-        private programRepository: UserMonitoringProgramD2Repository
+        private userRepository: TwoFactorUserRepository,
+        private reportRepository: TwoFactorReportRepository,
+        private configRepository: TwoFactorConfigRepository,
+        private programRepository: UserMonitoringProgramRepository
     ) {}
 
     async execute(twoFactorUseCaseOption: TwoFactorUseCaseOptions): Async<TwoFactorReportResponse> {
@@ -91,13 +94,12 @@ export class RunTwoFactorReportUseCase {
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
             if (invalidTwoFactorUsers.length > 0) {
-                const disableResponse = await this.disableUsersInBatches(
-                    invalidTwoFactorUsers.map(user => user.id),
-                    50
+                const disableResults = await this.userRepository.disableUsers(
+                    invalidTwoFactorUsers.map(user => user.id)
                 );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: disableResponse,
+                    disableUsersMessage: this.buildDisableUsersMessage(disableResults),
                     report,
                 };
             } else {
@@ -116,25 +118,17 @@ export class RunTwoFactorReportUseCase {
         };
     }
 
-    private async disableUsersInBatches(userIds: string[], batchSize: number): Async<string> {
-        const disableResults: Array<{ userId: string; status: string; response?: string; error?: unknown }> = [];
+    private buildDisableUsersMessage(disableResults: DisableUserResult[]): string {
+        const successes = disableResults.filter(r => r.status === "success");
+        const failures = disableResults.filter(r => r.status === "error");
 
-        for (const userIdsBatch of _.chunk(userIds, batchSize)) {
-            try {
-                const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
-                const batchResults = JSON.parse(batchResponse);
+        const failureDetails = failures
+            .map(f => `${f.userId}${f.error ? ` (${String(f.error)})` : ""}`)
+            .join(" | ");
 
-                disableResults.push(...batchResults);
-            } catch {
-                disableResults.push({
-                    userId: "unknown",
-                    status: "error",
-                    error: `Invalid disable users response for batch: ${userIdsBatch.join(",")}`,
-                });
-            }
-        }
-
-        return JSON.stringify(disableResults);
+        return `Disabled users action is enabled and executed. Success: ${successes.length}. Errors: ${
+            failures.length
+        }.${failureDetails ? ` Failed: ${failureDetails}` : ""}`;
     }
 }
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -303,13 +303,13 @@ function createUseCase({
     const userRepo = mock(TwoFactorUserD2Repository);
     when(userRepo.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenResolve(users);
     when(userRepo.disableUsers(anything())).thenResolve(
-        JSON.stringify([
+        [
             {
                 userId: "mock-user",
                 status: "success",
                 response: "Disabled users action is enabled and executed.",
             },
-        ])
+        ]
     );
 
     const reportRepo = mock(TwoFactorReportD2Repository);

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -302,7 +302,15 @@ function createUseCase({
 
     const userRepo = mock(TwoFactorUserD2Repository);
     when(userRepo.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenResolve(users);
-    when(userRepo.disableUsers(anything())).thenResolve("Disabled users action is enabled and executed.");
+    when(userRepo.disableUsers(anything())).thenResolve(
+        JSON.stringify([
+            {
+                userId: "mock-user",
+                status: "success",
+                response: "Disabled users action is enabled and executed.",
+            },
+        ])
+    );
 
     const reportRepo = mock(TwoFactorReportD2Repository);
     when(reportRepo.save(anything(), anything())).thenResolve("OK");


### PR DESCRIPTION
https://app.clickup.com/t/869c8hupk

This PR implements request batching for the user disabling process within RunTwoFactorReportUseCase.

The Problem: Previously, attempting to disable a large number of users simultaneously caused the server to crash or time out due to an excessive number of concurrent requests.

The Solution: I introduced a batching strategy with a limit of 50 users per block. This ensures system stability while keeping the implementation as surgical as possible, minimizing changes to the existing logic and response contract.