### PR TITLE
Feature/disable twfa users since creationdate

### DIFF
--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -78,7 +78,7 @@ type D2TwoFactorUserResponse = {
     disabled: boolean;
     externalAuth: boolean;
     userGroups: { id: string; name: string }[];
-    created?: string;
+    created: string;
     twoFA?: boolean;
     twoFactorEnabled?: boolean;
 };

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -4,7 +4,6 @@ import _ from "lodash";
 import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
-import { PermissionFixerUser } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUser";
 import { Async } from "domain/entities/Async";
 import { Method } from "@eyeseetea/d2-api/repositories/HttpClientRepository";
 
@@ -34,6 +33,7 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
                 disabled: user.disabled ?? false,
                 externalAuth: user.externalAuth ?? false,
                 userGroups: user.userGroups ?? [],
+                created: user.created,
             };
         });
     }
@@ -72,4 +72,15 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     }
 }
 
-type Users = { users: PermissionFixerUser[] };
+type D2TwoFactorUserResponse = {
+    id: string;
+    username: string;
+    disabled: boolean;
+    externalAuth: boolean;
+    userGroups: { id: string; name: string }[];
+    created?: string;
+    twoFA?: boolean;
+    twoFactorEnabled?: boolean;
+};
+
+type Users = { users: D2TwoFactorUserResponse[] };

--- a/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
+++ b/src/data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository.ts
@@ -1,11 +1,14 @@
 import { D2Api } from "types/d2-api";
 import log from "utils/log";
 import _ from "lodash";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
 import { PermissionFixerUser } from "domain/entities/user-monitoring/permission-fixer/PermissionFixerUser";
 import { Async } from "domain/entities/Async";
 import { Method } from "@eyeseetea/d2-api/repositories/HttpClientRepository";
+
+const DISABLE_USERS_BATCH_SIZE = 50;
 
 export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
     constructor(private api: D2Api) {}
@@ -35,30 +38,37 @@ export class TwoFactorUserD2Repository implements TwoFactorUserRepository {
         });
     }
 
-    async disableUsers(userIds: string[]): Async<string> {
+    async disableUsers(userIds: string[]): Async<DisableUserResult[]> {
         log.info(`Disabling users by ids: ${userIds.join(",")}`);
 
-        const results = await Promise.all(
-            userIds.map(async userId => {
-                try {
-                    const response = await this.api
-                        .request<string>({
-                            // TEMPORAL. See https://github.com/EyeSeeTea/d2-api/pull/171
-                            method: "patch" as Method,
-                            url: `/41/users/${userId}`,
-                            headers: { "Content-Type": "application/json-patch+json" },
-                            data: [{ op: "replace", path: "/disabled", value: true }],
-                        })
-                        .getData();
+        const results: DisableUserResult[] = [];
 
-                    return { userId, status: "success", response };
-                } catch (error) {
-                    log.error(`Error disabling user ${userId}:` + error);
-                    return { userId, status: "error", error };
-                }
-            })
-        );
-        return JSON.stringify(results);
+        for (const userIdsBatch of _.chunk(userIds, DISABLE_USERS_BATCH_SIZE)) {
+            const batchResults = await Promise.all(
+                userIdsBatch.map(async (userId): Promise<DisableUserResult> => {
+                    try {
+                        const response = await this.api
+                            .request<string>({
+                                // TEMPORAL. See https://github.com/EyeSeeTea/d2-api/pull/171
+                                method: "patch" as Method,
+                                url: `/41/users/${userId}`,
+                                headers: { "Content-Type": "application/json-patch+json" },
+                                data: [{ op: "replace", path: "/disabled", value: true }],
+                            })
+                            .getData();
+
+                        return { userId, status: "success", response };
+                    } catch (error) {
+                        log.error(`Error disabling user ${userId}:` + error);
+                        return { userId, status: "error", error };
+                    }
+                })
+            );
+
+            results.push(...batchResults);
+        }
+
+        return results;
     }
 }
 

--- a/src/domain/entities/DateTime.ts
+++ b/src/domain/entities/DateTime.ts
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 export type DateTimeIso8601 = string;
 
 /* Compare two ISO 8801 datetimes.
@@ -16,4 +18,15 @@ export function compareDateTimeIso8601(date1: DateTimeIso8601, date2: DateTimeIs
     } else {
         return "EQ";
     }
+}
+
+/* Get the number of complete months between two ISO dates.
+   Uses day-level precision: a month is only counted when the day of the later date
+   is >= the day of the earlier date. For example, 2026-03-31 to 2026-04-01 = 0 months.
+*/
+export function getMonthsDiff(startDate: string, endDate: string): number {
+    const start = DateTime.fromISO(startDate);
+    const end = DateTime.fromISO(endDate);
+    const diff = end.diff(start, "months").months;
+    return Math.floor(diff);
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult.ts
@@ -1,0 +1,8 @@
+export type DisableUserResultStatus = "success" | "error";
+
+export interface DisableUserResult {
+    userId: string;
+    status: DisableUserResultStatus;
+    response?: string;
+    error?: unknown;
+}

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
@@ -1,5 +1,6 @@
 import { Id, NamedRef } from "domain/entities/Base";
 import { Timestamp } from "domain/entities/Date";
+import { getMonthsDiff } from "domain/entities/DateTime";
 
 export interface TwoFactorUser {
     id: Id;
@@ -21,12 +22,9 @@ export function filterByCreationDate(
         );
     }
 
-    const now = new Date();
+    const now = new Date().toISOString();
     return users.filter(user => {
-        const createdDate = new Date(user.created);
-        const monthsDiff =
-            (now.getFullYear() - createdDate.getFullYear()) * 12 +
-            (now.getMonth() - createdDate.getMonth());
+        const monthsDiff = getMonthsDiff(user.created, now);
         return monthsDiff >= disableAfterMonths;
     });
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
@@ -1,5 +1,5 @@
 import { Id, NamedRef } from "domain/entities/Base";
-import { Maybe } from "utils/ts-utils";
+import { Timestamp } from "domain/entities/Date";
 
 export interface TwoFactorUser {
     id: Id;
@@ -8,7 +8,7 @@ export interface TwoFactorUser {
     disabled: boolean;
     externalAuth: boolean;
     userGroups: NamedRef[];
-    created: Maybe<string>;
+    created: Timestamp;
 }
 
 export function filterByCreationDate(
@@ -23,7 +23,6 @@ export function filterByCreationDate(
 
     const now = new Date();
     return users.filter(user => {
-        if (!user.created) return false;
         const createdDate = new Date(user.created);
         const monthsDiff =
             (now.getFullYear() - createdDate.getFullYear()) * 12 +

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser.ts
@@ -1,4 +1,5 @@
 import { Id, NamedRef } from "domain/entities/Base";
+import { Maybe } from "utils/ts-utils";
 
 export interface TwoFactorUser {
     id: Id;
@@ -7,4 +8,26 @@ export interface TwoFactorUser {
     disabled: boolean;
     externalAuth: boolean;
     userGroups: NamedRef[];
+    created: Maybe<string>;
+}
+
+export function filterByCreationDate(
+    users: TwoFactorUser[],
+    disableAfterMonths: number | undefined
+): TwoFactorUser[] {
+    if (disableAfterMonths === undefined) {
+        throw new Error(
+            "filteredByMonth is enabled but disableAfterMonths is not configured in the datastore."
+        );
+    }
+
+    const now = new Date();
+    return users.filter(user => {
+        if (!user.created) return false;
+        const createdDate = new Date(user.created);
+        const monthsDiff =
+            (now.getFullYear() - createdDate.getFullYear()) * 12 +
+            (now.getMonth() - createdDate.getMonth());
+        return monthsDiff >= disableAfterMonths;
+    });
 }

--- a/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
+++ b/src/domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions.ts
@@ -6,4 +6,5 @@ export interface TwoFactorUserOptions {
     twoFactorGroup: NamedRef;
     whoAccountGroup: Maybe<NamedRef>;
     exceptionGroup: Maybe<NamedRef[]>;
+    disableAfterMonths: Maybe<number>;
 }

--- a/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
+++ b/src/domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository.ts
@@ -1,6 +1,8 @@
 import { Async } from "domain/entities/Async";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 
 export interface TwoFactorUserRepository {
     getUsersNotInGroupIds(excludeUserGroupIds: string[]): Async<TwoFactorUser[]>;
+    disableUsers(userIds: string[]): Async<DisableUserResult[]>;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -5,6 +5,10 @@ import { Async } from "domain/entities/Async";
 import { TwoFactorReportRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorReportRepository";
 import { TwoFactorConfigRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorConfigRepository";
 import { UserMonitoringProgramRepository } from "domain/repositories/user-monitoring/common/UserMonitoringProgramRepository";
+import {
+    TwoFactorUser,
+    filterByCreationDate,
+} from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 
 type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 
@@ -18,6 +22,7 @@ export class RunTwoFactorReportUseCase {
 
     async execute(twoFactorUseCaseOption: TwoFactorUseCaseOptions): Async<TwoFactorReportResponse> {
         const shouldDisableInvalidUsers = twoFactorUseCaseOption.shouldDisableInvalidUsers;
+        const filteredByMonth = twoFactorUseCaseOption.filteredByMonth;
         const options = await this.configRepository.get();
         const programMetadata = await this.programRepository.get(options.pushProgram.id);
 
@@ -76,8 +81,12 @@ export class RunTwoFactorReportUseCase {
             return isEnabled && ((isInWhoGroup && isInAuthGroup) || isNotInWhoOr2FA);
         });
 
+        const filteredInvalidTwoFactorUsers = filteredByMonth
+            ? filterByCreationDate(invalidTwoFactorUsers, options.disableAfterMonths)
+            : invalidTwoFactorUsers;
+
         const report: TwoFactorUserReport = {
-            invalidTwoFAList: invalidTwoFactorUsers.map(user => {
+            invalidTwoFAList: filteredInvalidTwoFactorUsers.map(user => {
                 return { id: user.id, name: user.username };
             }),
             invalidWhoList: whoInvalidUsers.map(user => {
@@ -90,9 +99,9 @@ export class RunTwoFactorReportUseCase {
 
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
-            if (invalidTwoFactorUsers.length > 0) {
+            if (filteredInvalidTwoFactorUsers.length > 0) {
                 const disableResults = await this.userRepository.disableUsers(
-                    invalidTwoFactorUsers.map(user => user.id)
+                    filteredInvalidTwoFactorUsers.map(user => user.id)
                 );
                 return {
                     message: saveResponse,
@@ -127,8 +136,10 @@ export class RunTwoFactorReportUseCase {
             failures.length
         }.${failureDetails ? ` Failed: ${failureDetails}` : ""}`;
     }
+
 }
 
 interface TwoFactorUseCaseOptions {
     shouldDisableInvalidUsers: boolean;
+    filteredByMonth: boolean;
 }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -124,9 +124,7 @@ export class RunTwoFactorReportUseCase {
                 const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
                 const batchResults = JSON.parse(batchResponse);
 
-                if (Array.isArray(batchResults)) {
-                    disableResults.push(...batchResults);
-                }
+                disableResults.push(...batchResults);
             } catch {
                 disableResults.push({
                     userId: "unknown",

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -97,6 +97,10 @@ export class RunTwoFactorReportUseCase {
             }),
         };
 
+        const filterInfo = filteredByMonth
+            ? ` Filtered by creation date (disableAfterMonths: ${options.disableAfterMonths}).`
+            : "";
+
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
             if (filteredInvalidTwoFactorUsers.length > 0) {
@@ -105,14 +109,14 @@ export class RunTwoFactorReportUseCase {
                 );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: this.buildDisableUsersMessage(disableResults),
+                    disableUsersMessage: this.buildDisableUsersMessage(disableResults, filterInfo),
                     report,
                 };
             } else {
                 return {
                     message: saveResponse,
                     disableUsersMessage:
-                        "Disabled users action is not executed due to no invalid users found.",
+                        `Disabled users action is not executed due to no invalid users found.${filterInfo}`,
                     report,
                 };
             }
@@ -124,7 +128,7 @@ export class RunTwoFactorReportUseCase {
         };
     }
 
-    private buildDisableUsersMessage(disableResults: DisableUserResult[]): string {
+    private buildDisableUsersMessage(disableResults: DisableUserResult[], filterInfo: string): string {
         const successes = disableResults.filter(r => r.status === "success");
         const failures = disableResults.filter(r => r.status === "error");
 
@@ -132,7 +136,7 @@ export class RunTwoFactorReportUseCase {
             .map(f => `${f.userId}${f.error ? ` (${String(f.error)})` : ""}`)
             .join(" | ");
 
-        return `Disabled users action is enabled and executed. Success: ${successes.length}. Errors: ${
+        return `Disabled users action is enabled and executed.${filterInfo} Success: ${successes.length}. Errors: ${
             failures.length
         }.${failureDetails ? ` Failed: ${failureDetails}` : ""}`;
     }

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -91,12 +91,13 @@ export class RunTwoFactorReportUseCase {
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
             if (invalidTwoFactorUsers.length > 0) {
-                const disableResponse = await this.userRepository.disableUsers(
-                    invalidTwoFactorUsers.map(user => user.id)
+                const disableResponse = await this.disableUsersInBatches(
+                    invalidTwoFactorUsers.map(user => user.id),
+                    50
                 );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: JSON.stringify(disableResponse),
+                    disableUsersMessage: disableResponse,
                     report,
                 };
             } else {
@@ -113,6 +114,29 @@ export class RunTwoFactorReportUseCase {
             disableUsersMessage: "Disabled users action is not enabled.",
             report,
         };
+    }
+
+    private async disableUsersInBatches(userIds: string[], batchSize: number): Async<string> {
+        const disableResults: Array<{ userId: string; status: string; response?: string; error?: unknown }> = [];
+
+        for (const userIdsBatch of _.chunk(userIds, batchSize)) {
+            try {
+                const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
+                const batchResults = JSON.parse(batchResponse);
+
+                if (Array.isArray(batchResults)) {
+                    disableResults.push(...batchResults);
+                }
+            } catch {
+                disableResults.push({
+                    userId: "unknown",
+                    status: "error",
+                    error: `Invalid disable users response for batch: ${userIdsBatch.join(",")}`,
+                });
+            }
+        }
+
+        return JSON.stringify(disableResults);
     }
 }
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -1,8 +1,5 @@
 import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
 import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
-import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
-import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
-import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
 import { TwoFactorReportRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorReportRepository";

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/RunTwoFactorReportUseCase.ts
@@ -1,19 +1,22 @@
-import _ from "lodash";
-import { TwoFactorUserD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository";
+import { DisableUserResult } from "domain/entities/user-monitoring/two-factor-monitoring/DisableUsersResult";
+import { TwoFactorUserRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorUserRepository";
 import { TwoFactorConfigD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorConfigD2Repository";
 import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
 import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { TwoFactorUserReport } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserReport";
 import { Async } from "domain/entities/Async";
+import { TwoFactorReportRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorReportRepository";
+import { TwoFactorConfigRepository } from "domain/repositories/user-monitoring/two-factor-monitoring/TwoFactorConfigRepository";
+import { UserMonitoringProgramRepository } from "domain/repositories/user-monitoring/common/UserMonitoringProgramRepository";
 
 type TwoFactorReportResponse = { message: string; report: TwoFactorUserReport; disableUsersMessage: string };
 
 export class RunTwoFactorReportUseCase {
     constructor(
-        private userRepository: TwoFactorUserD2Repository,
-        private reportRepository: TwoFactorReportD2Repository,
-        private configRepository: TwoFactorConfigD2Repository,
-        private programRepository: UserMonitoringProgramD2Repository
+        private userRepository: TwoFactorUserRepository,
+        private reportRepository: TwoFactorReportRepository,
+        private configRepository: TwoFactorConfigRepository,
+        private programRepository: UserMonitoringProgramRepository
     ) {}
 
     async execute(twoFactorUseCaseOption: TwoFactorUseCaseOptions): Async<TwoFactorReportResponse> {
@@ -91,13 +94,12 @@ export class RunTwoFactorReportUseCase {
         const saveResponse = await this.reportRepository.save(programMetadata, report);
         if (shouldDisableInvalidUsers) {
             if (invalidTwoFactorUsers.length > 0) {
-                const disableResponse = await this.disableUsersInBatches(
-                    invalidTwoFactorUsers.map(user => user.id),
-                    50
+                const disableResults = await this.userRepository.disableUsers(
+                    invalidTwoFactorUsers.map(user => user.id)
                 );
                 return {
                     message: saveResponse,
-                    disableUsersMessage: disableResponse,
+                    disableUsersMessage: this.buildDisableUsersMessage(disableResults),
                     report,
                 };
             } else {
@@ -116,25 +118,17 @@ export class RunTwoFactorReportUseCase {
         };
     }
 
-    private async disableUsersInBatches(userIds: string[], batchSize: number): Async<string> {
-        const disableResults: Array<{ userId: string; status: string; response?: string; error?: unknown }> = [];
+    private buildDisableUsersMessage(disableResults: DisableUserResult[]): string {
+        const successes = disableResults.filter(r => r.status === "success");
+        const failures = disableResults.filter(r => r.status === "error");
 
-        for (const userIdsBatch of _.chunk(userIds, batchSize)) {
-            try {
-                const batchResponse = await this.userRepository.disableUsers(userIdsBatch);
-                const batchResults = JSON.parse(batchResponse);
+        const failureDetails = failures
+            .map(f => `${f.userId}${f.error ? ` (${String(f.error)})` : ""}`)
+            .join(" | ");
 
-                disableResults.push(...batchResults);
-            } catch {
-                disableResults.push({
-                    userId: "unknown",
-                    status: "error",
-                    error: `Invalid disable users response for batch: ${userIdsBatch.join(",")}`,
-                });
-            }
-        }
-
-        return JSON.stringify(disableResults);
+        return `Disabled users action is enabled and executed. Success: ${successes.length}. Errors: ${
+            failures.length
+        }.${failureDetails ? ` Failed: ${failureDetails}` : ""}`;
     }
 }
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -303,13 +303,13 @@ function createUseCase({
     const userRepo = mock(TwoFactorUserD2Repository);
     when(userRepo.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenResolve(users);
     when(userRepo.disableUsers(anything())).thenResolve(
-        JSON.stringify([
+        [
             {
                 userId: "mock-user",
                 status: "success",
                 response: "Disabled users action is enabled and executed.",
             },
-        ])
+        ]
     );
 
     const reportRepo = mock(TwoFactorReportD2Repository);

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -302,7 +302,15 @@ function createUseCase({
 
     const userRepo = mock(TwoFactorUserD2Repository);
     when(userRepo.getUsersNotInGroupIds(deepEqual(excludedGroupIds))).thenResolve(users);
-    when(userRepo.disableUsers(anything())).thenResolve("Disabled users action is enabled and executed.");
+    when(userRepo.disableUsers(anything())).thenResolve(
+        JSON.stringify([
+            {
+                userId: "mock-user",
+                status: "success",
+                response: "Disabled users action is enabled and executed.",
+            },
+        ])
+    );
 
     const reportRepo = mock(TwoFactorReportD2Repository);
     when(reportRepo.save(anything(), anything())).thenResolve("OK");

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -29,6 +29,7 @@ const baseUser = {
     disabled: false,
     twoFA: false,
     username: "testuser",
+    created: "2020-01-01T00:00:00.000",
 };
 
 const defaultConfig: TwoFactorUserOptions = {
@@ -36,6 +37,7 @@ const defaultConfig: TwoFactorUserOptions = {
     twoFactorGroup: { id: TWO_FACTOR_GROUP_ID, name: "2FA Group" },
     whoAccountGroup: { id: WHO_ACCOUNT_GROUP_ID, name: "WHO Group" },
     exceptionGroup: [{ id: EXCEPTION_GROUP_ID, name: "Exception Group" }],
+    disableAfterMonths: undefined,
 };
 const alternativeConfig: TwoFactorUserOptions = {
     pushProgram: {
@@ -51,10 +53,11 @@ const alternativeConfig: TwoFactorUserOptions = {
         name: "Who account usergroup",
     },
     exceptionGroup: [],
+    disableAfterMonths: undefined,
 };
 
-const useCaseOptionsDisabledFalse = { shouldDisableInvalidUsers: false };
-const useCaseOptionsDisabledTrue = { shouldDisableInvalidUsers: true };
+const useCaseOptionsDisabledFalse = { shouldDisableInvalidUsers: false, filteredByMonth: false };
+const useCaseOptionsDisabledTrue = { shouldDisableInvalidUsers: true, filteredByMonth: false };
 
 describe("TwoFactorReportUseCase", () => {
     it("Should detects a user in 2FA group with twoFA disabled as invalidTwoFA", async () => {
@@ -66,7 +69,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute({ shouldDisableInvalidUsers: false });
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false, filteredByMonth: false });
 
         expect(result.report.invalidTwoFAList).toEqual([{ id: "u1", name: "testuser" }]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -83,7 +86,7 @@ describe("TwoFactorReportUseCase", () => {
 
         const useCase = createUseCase({ users: [user], config: defaultConfig });
 
-        const result = await useCase.execute({ shouldDisableInvalidUsers: false });
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false, filteredByMonth: false });
 
         expect(result.report.invalidTwoFAList).toEqual([]);
         expect(result.report.invalidWhoList).toEqual([]);
@@ -286,6 +289,131 @@ describe("TwoFactorReportUseCase", () => {
         expect(result.report.invalidAuthList).toEqual([
             { id: userInvalidAuth.id, name: userInvalidAuth.username },
         ]);
+    });
+
+    it("Should throw error when filteredByMonth is true but disableAfterMonths is not configured", async () => {
+        const user: TwoFactorUser = {
+            ...baseUser,
+            id: "u1",
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const configWithoutMonths: TwoFactorUserOptions = {
+            ...defaultConfig,
+            disableAfterMonths: undefined,
+        };
+        const useCase = createUseCase({ users: [user], config: configWithoutMonths });
+
+        await expect(
+            useCase.execute({ shouldDisableInvalidUsers: false, filteredByMonth: true })
+        ).rejects.toThrow(
+            "filteredByMonth is enabled but disableAfterMonths is not configured in the datastore."
+        );
+    });
+
+    it("Should filter invalid users by creation date when filteredByMonth is true and disableAfterMonths is configured", async () => {
+        const now = new Date();
+        const oldDate = new Date(now.getFullYear() - 1, now.getMonth(), 1).toISOString();
+        const recentDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+        const oldUser: TwoFactorUser = {
+            ...baseUser,
+            id: "old-user",
+            username: "old-user",
+            created: oldDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const recentUser: TwoFactorUser = {
+            ...baseUser,
+            id: "recent-user",
+            username: "recent-user",
+            created: recentDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const configWithMonths: TwoFactorUserOptions = {
+            ...defaultConfig,
+            disableAfterMonths: 6,
+        };
+        const useCase = createUseCase({ users: [oldUser, recentUser], config: configWithMonths });
+
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false, filteredByMonth: true });
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "old-user", name: "old-user" }]);
+    });
+
+    it("Should not filter by date when filteredByMonth is false even if disableAfterMonths is configured", async () => {
+        const now = new Date();
+        const recentDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+        const recentUser: TwoFactorUser = {
+            ...baseUser,
+            id: "recent-user",
+            username: "recent-user",
+            created: recentDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const configWithMonths: TwoFactorUserOptions = {
+            ...defaultConfig,
+            disableAfterMonths: 6,
+        };
+        const useCase = createUseCase({ users: [recentUser], config: configWithMonths });
+
+        const result = await useCase.execute({ shouldDisableInvalidUsers: false, filteredByMonth: false });
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "recent-user", name: "recent-user" }]);
+    });
+
+    it("Should disable only filtered users when both disableUsers and filteredByMonth are true", async () => {
+        const now = new Date();
+        const oldDate = new Date(now.getFullYear() - 1, now.getMonth(), 1).toISOString();
+        const recentDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+        const oldUser: TwoFactorUser = {
+            ...baseUser,
+            id: "old-user",
+            username: "old-user",
+            created: oldDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const recentUser: TwoFactorUser = {
+            ...baseUser,
+            id: "recent-user",
+            username: "recent-user",
+            created: recentDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const configWithMonths: TwoFactorUserOptions = {
+            ...defaultConfig,
+            disableAfterMonths: 6,
+        };
+        const useCase = createUseCase({ users: [oldUser, recentUser], config: configWithMonths });
+
+        const result = await useCase.execute({ shouldDisableInvalidUsers: true, filteredByMonth: true });
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "old-user", name: "old-user" }]);
+        expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
+    });
+
+    it("Should disable all invalid users when disableUsers is true and filteredByMonth is false", async () => {
+        const now = new Date();
+        const recentDate = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+        const recentUser: TwoFactorUser = {
+            ...baseUser,
+            id: "recent-user",
+            username: "recent-user",
+            created: recentDate,
+            userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "TwoFactorGroup" }],
+        };
+        const configWithMonths: TwoFactorUserOptions = {
+            ...defaultConfig,
+            disableAfterMonths: 6,
+        };
+        const useCase = createUseCase({ users: [recentUser], config: configWithMonths });
+
+        const result = await useCase.execute({ shouldDisableInvalidUsers: true, filteredByMonth: false });
+
+        expect(result.report.invalidTwoFAList).toEqual([{ id: "recent-user", name: "recent-user" }]);
+        expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
     });
 });
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorReportUseCase.specs.ts
@@ -18,7 +18,7 @@ import {
 import { TwoFactorUserD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorUserD2Repository";
 import { TwoFactorReportD2Repository } from "data/user-monitoring/two-factor-monitoring/TwoFactorReportD2Repository";
 import { UserMonitoringProgramD2Repository } from "data/user-monitoring/common/UserMonitoringProgramD2Repository";
-import { TwoFactorUser } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
+import { TwoFactorUser, filterByCreationDate } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUser";
 import { TwoFactorUserOptions } from "domain/entities/user-monitoring/two-factor-monitoring/TwoFactorUserOptions";
 const TWO_FACTOR_GROUP_ID = "2FA";
 const WHO_ACCOUNT_GROUP_ID = "WHO";
@@ -414,6 +414,47 @@ describe("TwoFactorReportUseCase", () => {
 
         expect(result.report.invalidTwoFAList).toEqual([{ id: "recent-user", name: "recent-user" }]);
         expect(result.disableUsersMessage).contain("Disabled users action is enabled and executed.");
+    });
+});
+
+describe("filterByCreationDate", () => {
+    const makeUser = (created: string): TwoFactorUser => ({
+        ...baseUser,
+        id: "u1",
+        userGroups: [{ id: TWO_FACTOR_GROUP_ID, name: "" }],
+        created,
+    });
+
+    it("Should not filter a user created just 1 day before month boundary (edge case)", () => {
+        const now = new Date();
+        // User created on the last day of the previous month — less than 1 full month ago
+        const lastDayPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0).toISOString();
+        const result = filterByCreationDate([makeUser(lastDayPrevMonth)], 1);
+        expect(result).toEqual([]);
+    });
+
+    it("Should filter a user created exactly 1 month ago", () => {
+        const now = new Date();
+        // e.g. if now is 2026-03-26, this is 2026-02-26
+        const oneMonthAgo = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()).toISOString();
+        const result = filterByCreationDate([makeUser(oneMonthAgo)], 1);
+        expect(result).toHaveLength(1);
+    });
+
+    it("Should filter a user created 7 months ago with disableAfterMonths 6", () => {
+        const now = new Date();
+        // e.g. if now is 2026-03-26, this is 2025-08-26 (7 months ago)
+        const sevenMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 7, now.getDate()).toISOString();
+        const result = filterByCreationDate([makeUser(sevenMonthsAgo)], 6);
+        expect(result).toHaveLength(1);
+    });
+
+    it("Should filter all users when disableAfterMonths is 0", () => {
+        const now = new Date();
+        // e.g. if now is 2026-03-26, this is 2026-03-01 (first day of current month, 0 months diff)
+        const recent = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+        const result = filterByCreationDate([makeUser(recent)], 0);
+        expect(result).toHaveLength(1);
     });
 });
 

--- a/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
+++ b/src/domain/usecases/user-monitoring/two-factor-monitoring/__tests__/TwoFactorTest.data.ts
@@ -17,6 +17,7 @@ export const userWithTwoFA: TwoFactorUser = {
             name: "dummy_group_name",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const userInTwoFAGroupButWithExternalAuth: TwoFactorUser = {
@@ -31,6 +32,7 @@ export const userInTwoFAGroupButWithExternalAuth: TwoFactorUser = {
             name: "dummy_group_name",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const userWithoutTwoFA: TwoFactorUser = {
@@ -45,6 +47,7 @@ export const userWithoutTwoFA: TwoFactorUser = {
             name: "dummy_group_name",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const userWithTwoFAdisabled: TwoFactorUser = {
@@ -59,6 +62,7 @@ export const userWithTwoFAdisabled: TwoFactorUser = {
             name: "dummy_group_name",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 export const userWithoutTwoFAdisabled: TwoFactorUser = {
     id: "userUid2",
@@ -72,6 +76,7 @@ export const userWithoutTwoFAdisabled: TwoFactorUser = {
             name: "dummy_group_name",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const userWithoutExternalAuth: TwoFactorUser = {
@@ -86,6 +91,7 @@ export const userWithoutExternalAuth: TwoFactorUser = {
             name: "Who account usergroup",
         },
     ],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const userInvalidAuth: TwoFactorUser = {
@@ -95,6 +101,7 @@ export const userInvalidAuth: TwoFactorUser = {
     username: "username4",
     externalAuth: false,
     userGroups: [],
+    created: "2020-01-01T00:00:00.000",
 };
 
 export const mixedInvalidUsers: TwoFactorUser[] = [

--- a/src/scripts/commands/userMonitoring.ts
+++ b/src/scripts/commands/userMonitoring.ts
@@ -63,6 +63,13 @@ const run2FAReporterCmd = command({
             long: "disable-users",
             description: "Disable invalid twoFA users.",
         }),
+        filteredByMonth: flag({
+            type: boolean,
+            short: "f",
+            long: "filtered-by-month",
+            description:
+                "Filter users by creation date using disableAfterMonths from datastore config.",
+        }),
     },
 
     handler: async args => {
@@ -77,7 +84,10 @@ const run2FAReporterCmd = command({
             userMonitoringReportRepository,
             externalConfigRepository,
             programRepository
-        ).execute({ shouldDisableInvalidUsers: args.disableusers });
+        ).execute({
+            shouldDisableInvalidUsers: args.disableusers,
+            filteredByMonth: args.filteredByMonth,
+        });
 
         log.info(JSON.stringify(response));
     },


### PR DESCRIPTION
📌 References
Issue: Closes https://app.clickup.com/t/869c8hupk
📝 Implementation
Problem:
We have been disabling users weekly because they weren't activating their 2FA. However, with the new release, we can now force 2FA activation. This means we no longer need to disable accounts so quickly; instead, we can target only those users who haven't set up 2FA within X months of their account creation.

Solution:
Added disableAfterMonths dataset setting.
Added the --filtered-by-month CLI flag to run-2fa-reporter. Although it doesn't accept a specific month value via CLI, it acts as a toggle to enable the filtering logic. This allows us to maintain the specific threshold in the Datastore for easy updates while giving us the flexibility to enable or disable filtering at the server level.

When enabled, only invalid users whose account was created >= [disableAfterMonths] ago are reported/disabled.
Throws an error if --filtered-by-month is used but is not configured in the datastore (invalid config).

