### PR TITLE
fix: use global flag in regex to replace all whitespace in translation property names

### DIFF
--- a/src/data/ImportTranslationsRepositorySpreadsheetRepository.ts
+++ b/src/data/ImportTranslationsRepositorySpreadsheetRepository.ts
@@ -96,7 +96,7 @@ export class ImportTranslationsRepositorySpreadsheetRepository implements Import
                             if (isFirstRow) warn(`Locale not found in DB: name=${localeName}`);
                             return undefined;
                         } else {
-                            const property = _.upperCase(field).replace(/\s+/, "_");
+                            const property = _.upperCase(field).replace(/\s+/g, "_");
                             return { property: property, locale: locale.locale, value: text };
                         }
                     });


### PR DESCRIPTION
Closes https://app.clickup.com/t/4528615/869dek7uv

## Summary

- Without the `/g` flag, `String.replace(/\s+/, "_")` only replaced the first whitespace run
- Multi-word field names like `"LONG FORM NAME"` would produce `"LONG_FORM NAME"` instead of `"LONG_FORM_NAME"`, generating invalid DHIS2 translation property keys