### PR TITLE
feat(orgunits): add --exclude-by-name to rename-from-hierarchy

### DIFF
--- a/src/domain/usecases/RenameOrgUnitsFromHierarchyUseCase.ts
+++ b/src/domain/usecases/RenameOrgUnitsFromHierarchyUseCase.ts
@@ -9,10 +9,11 @@ export type ParentNamePosition = "prefix" | "suffix";
 export type RenameOrgUnitsFromHierarchyOptions = {
     rootIds: Id[];
     parentNameAs: ParentNamePosition;
+    excludeByName: string[];
     post: boolean;
 };
 
-export type RenameSummary = { total: number; renamed: number; skipped: number };
+export type RenameSummary = { total: number; renamed: number; skipped: number; excluded: number };
 
 const separator = " - ";
 const pageSize = 1000;
@@ -21,12 +22,14 @@ export class RenameOrgUnitsFromHierarchyUseCase {
     constructor(private orgUnitRepository: OrgUnitRepository) {}
 
     async execute(options: RenameOrgUnitsFromHierarchyOptions): Promise<RenameSummary> {
-        const { rootIds, parentNameAs, post } = options;
+        const { rootIds, parentNameAs, excludeByName, post } = options;
+        const excludedNames = new Set(excludeByName);
         logger.info(
-            `Rename leaf org units under roots [${rootIds.join(", ")}] with parent name as ${parentNameAs}`
+            `Rename leaf org units under roots [${rootIds.join(", ")}] with parent name as ${parentNameAs}` +
+                (excludedNames.size > 0 ? `, excluding names [${excludeByName.join(", ")}]` : "")
         );
 
-        const summary: RenameSummary = { total: 0, renamed: 0, skipped: 0 };
+        const summary: RenameSummary = { total: 0, renamed: 0, skipped: 0, excluded: 0 };
         let page = 1;
 
         // eslint-disable-next-line no-constant-condition
@@ -36,14 +39,16 @@ export class RenameOrgUnitsFromHierarchyUseCase {
                 pageSize,
             });
 
-            const renames = leaves.map(leaf => this.getRename(leaf, parentNameAs));
+            const renames = leaves.map(leaf => this.getRename(leaf, parentNameAs, excludedNames));
             const toRename = renames.filter(rename => !rename.skipped);
+            const excluded = renames.filter(rename => rename.excluded);
 
             this.logRenames(renames);
 
             summary.total += renames.length;
             summary.renamed += toRename.length;
-            summary.skipped += renames.length - toRename.length;
+            summary.excluded += excluded.length;
+            summary.skipped += renames.length - toRename.length - excluded.length;
 
             if (post && !_.isEmpty(toRename)) {
                 await this.orgUnitRepository.save(
@@ -58,15 +63,23 @@ export class RenameOrgUnitsFromHierarchyUseCase {
         logger.info(
             `${summary.total} leaves: ${summary.renamed} ${post ? "renamed" : "to rename"}, ${
                 summary.skipped
-            } unchanged`
+            } unchanged, ${summary.excluded} excluded`
         );
 
         return summary;
     }
 
-    private getRename(leaf: OrgUnit, position: ParentNamePosition): Rename {
+    private getRename(leaf: OrgUnit, position: ParentNamePosition, excludedNames: Set<string>): Rename {
+        const keep = (newName: string) => ({ orgUnit: leaf, oldName: leaf.name, newName, skipped: true });
+
         const parent = leaf.parent;
-        if (!parent) return { orgUnit: leaf, oldName: leaf.name, newName: leaf.name, skipped: true };
+        if (!parent) return keep(leaf.name);
+
+        // Skip if the excluded name appears anywhere in the leaf's path (leaf or any ancestor).
+        const pathNames = [...leaf.ancestors.map(ancestor => ancestor.name), leaf.name];
+        if (pathNames.some(name => excludedNames.has(name))) {
+            return { ...keep(leaf.name), excluded: true };
+        }
 
         const base = stripOneSegment(leaf.name, position);
         const newName =
@@ -79,13 +92,19 @@ export class RenameOrgUnitsFromHierarchyUseCase {
         renames.forEach(rename => {
             const from = rename.orgUnit.namePath;
             const to = rename.orgUnit.rename(rename.newName).namePath;
-            const suffix = from === to ? " (unchanged)" : "";
+            const suffix = rename.excluded ? " (excluded)" : from === to ? " (unchanged)" : "";
             logger.info(`${from} -> ${to}${suffix}`);
         });
     }
 }
 
-type Rename = { orgUnit: OrgUnit; oldName: string; newName: string; skipped: boolean };
+type Rename = {
+    orgUnit: OrgUnit;
+    oldName: string;
+    newName: string;
+    skipped: boolean;
+    excluded?: boolean;
+};
 
 /* Recover the base name by removing one affix segment: the last segment for suffix, the first for
    prefix. A name with no separator is returned unchanged (no affix yet). */

--- a/src/domain/usecases/__tests__/RenameOrgUnitsFromHierarchyUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/RenameOrgUnitsFromHierarchyUseCase.spec.ts
@@ -10,16 +10,16 @@ describe("RenameOrgUnitsFromHierarchyUseCase", () => {
     test("adds the parent name as suffix", async () => {
         const { useCase, repository } = setup([leaf("Mental Health")]);
 
-        const summary = await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: true });
+        const summary = await useCase.execute(options({ parentNameAs: "suffix" }));
 
-        expect(summary).toEqual({ total: 1, renamed: 1, skipped: 0 });
+        expect(summary).toEqual({ total: 1, renamed: 1, skipped: 0, excluded: 0 });
         expect(repository.saved.map(ou => ou.name)).toEqual(["Mental Health - Gaza Secondary Healthcare"]);
     });
 
     test("adds the parent name as prefix", async () => {
         const { useCase, repository } = setup([leaf("Mental Health")]);
 
-        await useCase.execute({ rootIds: [parent.id], parentNameAs: "prefix", post: true });
+        await useCase.execute(options({ parentNameAs: "prefix" }));
 
         expect(repository.saved.map(ou => ou.name)).toEqual(["Gaza Secondary Healthcare - Mental Health"]);
     });
@@ -27,18 +27,18 @@ describe("RenameOrgUnitsFromHierarchyUseCase", () => {
     test("does not write anything on a dry run (post=false)", async () => {
         const { useCase, repository } = setup([leaf("Mental Health")]);
 
-        const summary = await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: false });
+        const summary = await useCase.execute(options({ parentNameAs: "suffix", post: false }));
 
-        expect(summary).toEqual({ total: 1, renamed: 1, skipped: 0 });
+        expect(summary).toEqual({ total: 1, renamed: 1, skipped: 0, excluded: 0 });
         expect(repository.saved).toEqual([]);
     });
 
     test("is idempotent: a re-run with an unchanged parent skips the leaf", async () => {
         const { useCase, repository } = setup([leaf("Mental Health - Gaza Secondary Healthcare")]);
 
-        const summary = await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: true });
+        const summary = await useCase.execute(options({ parentNameAs: "suffix" }));
 
-        expect(summary).toEqual({ total: 1, renamed: 0, skipped: 1 });
+        expect(summary).toEqual({ total: 1, renamed: 0, skipped: 1, excluded: 0 });
         expect(repository.saved).toEqual([]);
     });
 
@@ -48,7 +48,7 @@ describe("RenameOrgUnitsFromHierarchyUseCase", () => {
             leaf("Mental Health - Gaza Secondary Healthcare", renamedParent),
         ]);
 
-        await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: true });
+        await useCase.execute(options({ parentNameAs: "suffix" }));
 
         expect(repository.saved.map(ou => ou.name)).toEqual([
             "Mental Health - Gaza Secondary Healthcare Center",
@@ -58,9 +58,44 @@ describe("RenameOrgUnitsFromHierarchyUseCase", () => {
     test("known limitation: a base name containing the separator is mis-split on first run", async () => {
         const { useCase, repository } = setup([leaf("Mental Health - Adults")]);
 
-        await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: true });
+        await useCase.execute(options({ parentNameAs: "suffix" }));
 
         // "Adults" is dropped because it is treated as the existing affix segment.
+        expect(repository.saved.map(ou => ou.name)).toEqual(["Mental Health - Gaza Secondary Healthcare"]);
+    });
+
+    test("excludes a leaf when its own name matches exactly", async () => {
+        const { useCase, repository } = setup([
+            leaf("Mental Health"),
+            leaf("Pharmacy", parent, "LEAF0001bbb"),
+        ]);
+
+        const summary = await useCase.execute(
+            options({ parentNameAs: "suffix", excludeByName: ["Mental Health"] })
+        );
+
+        expect(summary).toEqual({ total: 2, renamed: 1, skipped: 0, excluded: 1 });
+        expect(repository.saved.map(ou => ou.name)).toEqual(["Pharmacy - Gaza Secondary Healthcare"]);
+    });
+
+    test("excludes a leaf when an ancestor name matches exactly", async () => {
+        const { useCase, repository } = setup([leaf("Mental Health")]);
+
+        const summary = await useCase.execute(
+            options({ parentNameAs: "suffix", excludeByName: [parent.name] })
+        );
+
+        expect(summary).toEqual({ total: 1, renamed: 0, skipped: 0, excluded: 1 });
+        expect(repository.saved).toEqual([]);
+    });
+
+    test("exclusion requires an exact name match (no partial/case match)", async () => {
+        const { useCase, repository } = setup([leaf("Mental Health")]);
+
+        await useCase.execute(
+            options({ parentNameAs: "suffix", excludeByName: ["mental health", "Mental"] })
+        );
+
         expect(repository.saved.map(ou => ou.name)).toEqual(["Mental Health - Gaza Secondary Healthcare"]);
     });
 
@@ -68,13 +103,19 @@ describe("RenameOrgUnitsFromHierarchyUseCase", () => {
         const leaves = _range(2500).map(index => leaf(`OU ${index}`, parent, `LEAF${pad(index)}`));
         const { useCase, repository } = setup(leaves);
 
-        const summary = await useCase.execute({ rootIds: [parent.id], parentNameAs: "suffix", post: true });
+        const summary = await useCase.execute(options({ parentNameAs: "suffix" }));
 
         expect(summary.total).toBe(2500);
         expect(summary.renamed).toBe(2500);
         expect(repository.saved).toHaveLength(2500);
     });
 });
+
+function options(
+    overrides: Partial<Parameters<RenameOrgUnitsFromHierarchyUseCase["execute"]>[0]>
+): Parameters<RenameOrgUnitsFromHierarchyUseCase["execute"]>[0] {
+    return { rootIds: [parent.id], parentNameAs: "suffix", excludeByName: [], post: true, ...overrides };
+}
 
 function setup(orgUnits: OrgUnit[]) {
     const repository = new OrgUnitTestRepository(orgUnits);

--- a/src/scripts/commands/orgunits/renameFromHierarchyCmd.ts
+++ b/src/scripts/commands/orgunits/renameFromHierarchyCmd.ts
@@ -1,4 +1,4 @@
-import { command, flag, option } from "cmd-ts";
+import { array, command, flag, multioption, option, string } from "cmd-ts";
 import { OrgUnitD2Repository } from "data/OrgUnitD2Repository";
 import {
     ParentNamePosition,
@@ -31,6 +31,12 @@ export const renameFromHierarchyCmd = command({
             long: "parent-name-as",
             description: "Where to place the parent name: prefix | suffix",
         }),
+        excludeByName: multioption({
+            type: array(string),
+            long: "exclude-by-name",
+            description:
+                "Exclude leaves from renaming when this exact name appears anywhere in their path (leaf or any ancestor). Repeatable.",
+        }),
         post: flag({
             long: "post",
             description: "Apply the renames (without it, the command only previews the changes)",
@@ -44,12 +50,13 @@ export const renameFromHierarchyCmd = command({
         const summary = await useCase.execute({
             rootIds: args.rootOrgUnitIds,
             parentNameAs: args.parentNameAs,
+            excludeByName: args.excludeByName,
             post: args.post,
         });
 
         const action = args.post ? "renamed" : "to rename";
         console.info(
-            `${summary.total} leaf org units (${summary.renamed} ${action}, ${summary.skipped} unchanged)`
+            `${summary.total} leaf org units (${summary.renamed} ${action}, ${summary.skipped} unchanged, ${summary.excluded} excluded)`
         );
     },
 });


### PR DESCRIPTION
https://app.clickup.com/t/4528615/869df0fpk

## Summary
Adds an `--exclude-by-name="NAME"` option to the `orgunits rename-from-hierarchy` command to skip org units from being renamed.

- A leaf is excluded when the **exact** name appears anywhere in its path (the leaf itself or any ancestor). Matching is case-sensitive.
- The option is repeatable (`--exclude-by-name="A" --exclude-by-name="B"`).


## Tests
Added cases for exclusion by the leaf's own name, by an ancestor name, and exact-match-only behavior. All tests pass.