### PR TITLE
translations to-spreadsheet: --program-id filter and short locale references

### DIFF
--- a/src/data/ExportTranslationsSpreadsheetRepository.ts
+++ b/src/data/ExportTranslationsSpreadsheetRepository.ts
@@ -77,7 +77,9 @@ export class ExportTranslationsSpreadsheetRepository implements ExportTranslatio
 
         _.forEach(files, (content, name) => {
             if (!/^xl\/worksheets\/sheet\d+\.xml$/.test(name)) return;
-            const xml = decoder.decode(content).replace(/<sheetView ([^>]*?)\/>/, `<sheetView $1>${pane}</sheetView>`);
+            const xml = decoder
+                .decode(content)
+                .replace(/<sheetView ([^>]*?)\/>/, `<sheetView $1>${pane}</sheetView>`);
             files[name] = encoder.encode(xml);
         });
 
@@ -139,26 +141,37 @@ export class ExportTranslationsSpreadsheetRepository implements ExportTranslatio
             ...sheet.locales.map(locale => this.getTranslationColumn(field, locale)),
         ]);
 
-        return ["Type", "UID", ...fieldColumns];
+        return ["Type", "UID", "Name", ...fieldColumns];
     }
 
     /* Per-column color descriptors, aligned with getHeader. */
     private getColumnStyles(sheet: ModelTranslationsExport): ColumnStyle[] {
-        const meta: ColumnStyle = { kind: "meta", headerColor: metaColor.header, bodyColor: metaColor.body };
+        const meta: ColumnStyle = {
+            kind: "meta",
+            headerColor: metaColor.header,
+            bodyColor: metaColor.body,
+        };
 
         const fieldColumns = sheet.fields.flatMap((_field, index): ColumnStyle[] => {
             const palette = fieldPalette[index % fieldPalette.length];
             if (!palette) return [];
-            const base: ColumnStyle = { kind: "base", headerColor: palette.header, bodyColor: palette.base };
-            const locales = sheet.locales.map((): ColumnStyle => ({
-                kind: "locale",
+
+            const base: ColumnStyle = {
+                kind: "base",
                 headerColor: palette.header,
-                bodyColor: palette.locale,
-            }));
+                bodyColor: palette.base,
+            };
+            const locales = sheet.locales.map(
+                (): ColumnStyle => ({
+                    kind: "locale",
+                    headerColor: palette.header,
+                    bodyColor: palette.locale,
+                })
+            );
             return [base, ...locales];
         });
 
-        return [meta, meta, ...fieldColumns];
+        return [meta, meta, meta, ...fieldColumns];
     }
 
     private getRow(object: MetadataObjectWithTranslations, sheet: ModelTranslationsExport): string[] {
@@ -167,7 +180,7 @@ export class ExportTranslationsSpreadsheetRepository implements ExportTranslatio
             ...sheet.locales.map(locale => this.getTranslationValue(object, field, locale)),
         ]);
 
-        return [getSingularModel(sheet.model), object.id, ...fieldCells];
+        return [getSingularModel(sheet.model), object.id, object.name, ...fieldCells];
     }
 
     private getTranslationColumn(field: string, locale: Locale): string {

--- a/src/data/MetadataD2Repository.ts
+++ b/src/data/MetadataD2Repository.ts
@@ -152,9 +152,7 @@ export class MetadataD2Repository implements MetadataRepository {
         programId: Id
     ): Async<MetadataObjectWithTranslations[]> {
         log.debug(`GET program metadata: ${programId}`);
-        const metadata = await this.api
-            .get<Metadata>(`/programs/${programId}/metadata.json`)
-            .getData();
+        const metadata = await this.api.get<Metadata>(`/programs/${programId}/metadata.json`).getData();
 
         const requestedModels = models.map(getPluralModel);
         return this.mapMetadataObjects(_.pick(metadata, requestedModels));

--- a/src/data/MetadataD2Repository.ts
+++ b/src/data/MetadataD2Repository.ts
@@ -2,7 +2,12 @@ import _ from "lodash";
 import { D2Api } from "@eyeseetea/d2-api/2.36";
 import { Async } from "domain/entities/Async";
 import { Id } from "domain/entities/Base";
-import { MetadataRepository, Payload, SaveOptions } from "domain/repositories/MetadataRepository";
+import {
+    GetTranslationsOptions,
+    MetadataRepository,
+    Payload,
+    SaveOptions,
+} from "domain/repositories/MetadataRepository";
 import { getPluralModel, runMetadata } from "./dhis2-utils";
 import log from "utils/log";
 import {
@@ -18,8 +23,13 @@ import { Paginated } from "domain/entities/Pagination";
 export class MetadataD2Repository implements MetadataRepository {
     constructor(private api: D2Api) {}
 
-    async getAllWithTranslations(models: string[]): Async<MetadataObjectWithTranslations[]> {
-        return this.getMetadataObjects(models);
+    async getAllWithTranslations(
+        models: string[],
+        options?: GetTranslationsOptions
+    ): Async<MetadataObjectWithTranslations[]> {
+        return options?.programId
+            ? this.getProgramMetadataObjects(models, options.programId)
+            : this.getMetadataObjects(models);
     }
 
     async save(objects: MetadataObject[], options: SaveOptions): Async<{ payload: Payload; stats: object }> {
@@ -131,7 +141,26 @@ export class MetadataD2Repository implements MetadataRepository {
 
     private async getMetadataObjects(models: string[]): Async<MetadataObjectWithTranslations[]> {
         const metadata = await this.getD2Metadata(models);
+        return this.mapMetadataObjects(metadata);
+    }
 
+    /* Get objects from a program's metadata dependency export, keeping only the requested models.
+       The export groups objects by plural model name (plus non-array keys like "system", which
+       _.pick drops since they are not among the requested models). */
+    private async getProgramMetadataObjects(
+        models: string[],
+        programId: Id
+    ): Async<MetadataObjectWithTranslations[]> {
+        log.debug(`GET program metadata: ${programId}`);
+        const metadata = await this.api
+            .get<Metadata>(`/programs/${programId}/metadata.json`)
+            .getData();
+
+        const requestedModels = models.map(getPluralModel);
+        return this.mapMetadataObjects(_.pick(metadata, requestedModels));
+    }
+
+    private mapMetadataObjects(metadata: Metadata): MetadataObjectWithTranslations[] {
         return _(metadata)
             .toPairs()
             .flatMap(([modelPlural, d2Objects]) => {

--- a/src/data/MetadataD2Repository.ts
+++ b/src/data/MetadataD2Repository.ts
@@ -198,7 +198,8 @@ type D2Object = D2ObjectBase & {
 };
 
 function buildObject(object: MetadataObject): Partial<D2Object> {
-    return object;
+    // `model` is an internal-only field used for grouping; it must not leak into the metadata payload.
+    return _.omit(object, ["model"]);
 }
 
 interface BasicD2Object {

--- a/src/data/__tests__/ExportTranslationsSpreadsheetRepository.spec.ts
+++ b/src/data/__tests__/ExportTranslationsSpreadsheetRepository.spec.ts
@@ -20,6 +20,7 @@ describe("ExportTranslationsSpreadsheetRepository.buildSheet", () => {
         expect(header).toEqual([
             "Type",
             "UID",
+            "Name",
             "name",
             "name: French",
             "name: Spanish",
@@ -41,7 +42,8 @@ describe("ExportTranslationsSpreadsheetRepository.buildSheet", () => {
         expect(rows[0]).toEqual([
             "dataElement",
             "id1",
-            "Hello",
+            "Hello", // Name (object.name)
+            "Hello", // name source value
             "Bonjour", // NAME / fr
             "", // NAME / es (missing)
             "HelloForm", // formName source value
@@ -50,7 +52,7 @@ describe("ExportTranslationsSpreadsheetRepository.buildSheet", () => {
         ]);
 
         // Second object has no formName field at all -> base column blank.
-        expect(rows[1]).toEqual(["dataElement", "id2", "Second", "", "", "", "", ""]);
+        expect(rows[1]).toEqual(["dataElement", "id2", "Second", "Second", "", "", "", "", ""]);
     });
 });
 
@@ -71,7 +73,7 @@ describe("ExportTranslationsSpreadsheetRepository.save (file round-trip)", () =>
         const rows = XLSX.utils.sheet_to_json<string[]>(worksheet, { header: 1, defval: "" });
         expect(rows[0]?.[0]).toBe("Type");
         expect(rows).toHaveLength(3); // header + 2 objects
-        expect(worksheet["!autofilter"]?.ref).toBe("A1:H3");
+        expect(worksheet["!autofilter"]?.ref).toBe("A1:I3");
     });
 
     test("with includeData=false the sheet has only the header row", async () => {
@@ -81,7 +83,7 @@ describe("ExportTranslationsSpreadsheetRepository.save (file round-trip)", () =>
         const worksheet = getSheet(workbook, "dataElements");
         const rows = XLSX.utils.sheet_to_json<string[]>(worksheet, { header: 1, defval: "" });
         expect(rows).toHaveLength(1);
-        expect(worksheet["!autofilter"]?.ref).toBe("A1:H1");
+        expect(worksheet["!autofilter"]?.ref).toBe("A1:I1");
     });
 });
 

--- a/src/domain/repositories/MetadataRepository.ts
+++ b/src/domain/repositories/MetadataRepository.ts
@@ -1,4 +1,5 @@
 import { Async } from "domain/entities/Async";
+import { Id } from "domain/entities/Base";
 import {
     MetadataModel,
     MetadataObject,
@@ -8,11 +9,20 @@ import { Paginated } from "domain/entities/Pagination";
 
 export interface MetadataRepository {
     getPaginated(options: { model: MetadataModel; page: number }): Async<Paginated<MetadataObject>>;
-    getAllWithTranslations(models: MetadataModel[]): Async<MetadataObjectWithTranslations[]>;
+    getAllWithTranslations(
+        models: MetadataModel[],
+        options?: GetTranslationsOptions
+    ): Async<MetadataObjectWithTranslations[]>;
     save<Obj extends MetadataObject>(
         objects: Obj[],
         options: SaveOptions
     ): Async<{ payload: Payload; stats: object }>;
+}
+
+/* When programId is set, objects are taken from that program's metadata dependency export
+   (/api/programs/{id}/metadata) instead of the whole instance. */
+export interface GetTranslationsOptions {
+    programId?: Id;
 }
 
 export type Payload = Record<MetadataModel, object[]>;

--- a/src/domain/usecases/ExportTranslationsUseCase.ts
+++ b/src/domain/usecases/ExportTranslationsUseCase.ts
@@ -6,6 +6,7 @@ import { LocalesRepository } from "domain/repositories/LocalesRepository";
 import { ExportTranslationsRepository } from "domain/repositories/ExportTranslationsRepository";
 import { ModelTranslationsExport } from "domain/entities/ModelTranslationsExport";
 import { getPluralModel } from "data/dhis2-utils";
+import { Maybe } from "utils/ts-utils";
 import log from "utils/log";
 
 export interface ModelSelection {
@@ -51,23 +52,48 @@ export class ExportTranslationsUseCase {
         await this.repositories.exportTranslations.save({ outputFile, sheets, includeData });
     }
 
-    /* Match requested locale names against DB locales, ignoring any " (...)" suffix and case
-       (mirrors the import matching). Example: "Spanish" matches "Spanish (Spain)". */
+    /* Resolve each requested name to a DB locale, allowing short references. The resolved locale's
+       name is stripped of its " (...)" suffix so the column header round-trips with the import
+       (which matches headers against suffix-stripped DB names). */
     private resolveLocales(dbLocales: Locale[], requestedNames: string[]): Locale[] {
-        const stripName = (name: string) =>
-            name
-                .replace(/\s*\(.*\)$/, "")
-                .trim()
-                .toLowerCase();
-        const localesByName = _.keyBy(dbLocales, locale => stripName(locale.name));
-
         return _(requestedNames)
-            .map(name => {
-                const locale = localesByName[stripName(name)];
-                if (!locale) log.warn(`Locale not found in DB: ${name}`);
-                return locale;
-            })
+            .map(name => this.resolveLocale(dbLocales, name))
             .compact()
             .value();
     }
+
+    /* Match one requested name against DB locales, ignoring case and any " (...)" suffix. An exact
+       base-name match wins; otherwise fall back to a substring match, so "Sotho" resolves to
+       "Southern Sotho (Lesotho)". A substring matching more than one locale is ambiguous and errors;
+       no match warns and is skipped. Example: "Spanish" matches "Spanish (Spain)". */
+    private resolveLocale(dbLocales: Locale[], requestedName: string): Maybe<Locale> {
+        const target = normalizeLocaleName(requestedName);
+        if (!target) return undefined;
+
+        const exact = dbLocales.filter(locale => normalizeLocaleName(locale.name) === target);
+        const matches =
+            exact.length > 0
+                ? exact
+                : dbLocales.filter(locale => normalizeLocaleName(locale.name).includes(target));
+
+        if (matches.length === 0) {
+            log.warn(`Locale not found in DB: ${requestedName}`);
+            return undefined;
+        } else if (matches.length > 1) {
+            const names = matches.map(locale => locale.name).join(", ");
+            throw new Error(`Ambiguous locale "${requestedName}", matches ${matches.length}: ${names}`);
+        }
+
+        const locale = matches[0]!;
+        return { ...locale, name: stripLocaleSuffix(locale.name) };
+    }
+}
+
+/* Drop a trailing " (...)" country/variant qualifier, keeping the original case. */
+function stripLocaleSuffix(name: string): string {
+    return name.replace(/\s*\(.*\)$/, "").trim();
+}
+
+function normalizeLocaleName(name: string): string {
+    return stripLocaleSuffix(name).toLowerCase();
 }

--- a/src/domain/usecases/ExportTranslationsUseCase.ts
+++ b/src/domain/usecases/ExportTranslationsUseCase.ts
@@ -18,6 +18,7 @@ interface Options {
     models: ModelSelection[];
     locales: string[]; // locale names, e.g. ["Spanish", "French"]
     includeData: boolean;
+    programId?: string; // when set, scope the export to this program's metadata dependency export
 }
 
 export class ExportTranslationsUseCase {
@@ -30,14 +31,16 @@ export class ExportTranslationsUseCase {
     ) {}
 
     async execute(options: Options): Async<void> {
-        const { outputFile, models, includeData } = options;
+        const { outputFile, models, includeData, programId } = options;
         const allLocales = await this.repositories.locales.get();
         const locales = this.resolveLocales(allLocales, options.locales);
 
         const sheets = await Promise.all(
             models.map(async (selection): Promise<ModelTranslationsExport> => {
                 const model = getPluralModel(selection.model);
-                const objects = await this.repositories.metadata.getAllWithTranslations([model]);
+                const objects = await this.repositories.metadata.getAllWithTranslations([model], {
+                    programId,
+                });
 
                 log.info(`${model}: ${objects.length} objects`);
 

--- a/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
@@ -30,6 +30,40 @@ describe("ExportTranslationsUseCase", () => {
         expect(warn).toHaveBeenCalledWith(expect.stringContaining("Klingon"));
     });
 
+    test("resolves a short reference by substring and strips the suffix from the column name", async () => {
+        const { useCase, exportTranslations } = buildUseCase([
+            { id: "1", name: "Southern Sotho (Lesotho)", locale: "st" },
+            { id: "2", name: "Thai (Thailand)", locale: "th" },
+        ]);
+
+        await useCase.execute({
+            outputFile: "out.xlsx",
+            models: [{ model: "dataElement", fields: ["name"] }],
+            locales: ["Sotho", "Thai"],
+            includeData: false,
+        });
+
+        const { sheets } = exportTranslations.save.mock.calls[0][0];
+        expect(sheets[0].locales.map((l: Locale) => l.locale)).toEqual(["st", "th"]);
+        expect(sheets[0].locales.map((l: Locale) => l.name)).toEqual(["Southern Sotho", "Thai"]);
+    });
+
+    test("throws when a reference is ambiguous (matches more than one locale)", async () => {
+        const { useCase } = buildUseCase([
+            { id: "1", name: "Norwegian Bokmål (Norway)", locale: "nb" },
+            { id: "2", name: "Norwegian Nynorsk (Norway)", locale: "nn" },
+        ]);
+
+        await expect(
+            useCase.execute({
+                outputFile: "out.xlsx",
+                models: [{ model: "dataElement", fields: ["name"] }],
+                locales: ["Norwegian"],
+                includeData: false,
+            })
+        ).rejects.toThrow(/Ambiguous locale "Norwegian"/);
+    });
+
     test("pluralizes the requested model for both the fetch and the sheet", async () => {
         const { useCase, metadata, exportTranslations } = buildUseCase();
 
@@ -87,7 +121,7 @@ describe("ExportTranslationsUseCase", () => {
     });
 });
 
-function buildUseCase() {
+function buildUseCase(localesList: Locale[] = locales) {
     const object: MetadataObjectWithTranslations = {
         model: "dataElements",
         id: "abc",
@@ -102,7 +136,7 @@ function buildUseCase() {
         save: vi.fn(),
     } as unknown as MetadataRepository;
 
-    const localesRepo: LocalesRepository = { get: vi.fn().mockResolvedValue(locales) };
+    const localesRepo: LocalesRepository = { get: vi.fn().mockResolvedValue(localesList) };
     const exportTranslations = { save: vi.fn().mockResolvedValue(undefined) };
 
     const useCase = new ExportTranslationsUseCase({

--- a/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
@@ -40,9 +40,27 @@ describe("ExportTranslationsUseCase", () => {
             includeData: true,
         });
 
-        expect(metadata.getAllWithTranslations).toHaveBeenCalledWith(["dataElements"]);
+        expect(metadata.getAllWithTranslations).toHaveBeenCalledWith(["dataElements"], {
+            programId: undefined,
+        });
         const { sheets } = exportTranslations.save.mock.calls[0][0];
         expect(sheets[0].model).toBe("dataElements");
+    });
+
+    test("scopes the fetch to the given program when programId is set", async () => {
+        const { useCase, metadata } = buildUseCase();
+
+        await useCase.execute({
+            outputFile: "out.xlsx",
+            models: [{ model: "dataElement", fields: ["name"] }],
+            locales: ["French"],
+            includeData: true,
+            programId: "PROG123",
+        });
+
+        expect(metadata.getAllWithTranslations).toHaveBeenCalledWith(["dataElements"], {
+            programId: "PROG123",
+        });
     });
 
     test("builds one sheet per model and passes outputFile/includeData through", async () => {

--- a/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/ExportTranslationsUseCase.spec.ts
@@ -113,10 +113,7 @@ describe("ExportTranslationsUseCase", () => {
         const options = exportTranslations.save.mock.calls[0][0];
         expect(options.outputFile).toBe("translations.xlsx");
         expect(options.includeData).toBe(true);
-        expect(options.sheets.map((s: { model: string }) => s.model)).toEqual([
-            "dataElements",
-            "indicators",
-        ]);
+        expect(options.sheets.map((s: { model: string }) => s.model)).toEqual(["dataElements", "indicators"]);
         expect(options.sheets[0].fields).toEqual(["name", "formName"]);
     });
 });

--- a/src/scripts/commands/translations.ts
+++ b/src/scripts/commands/translations.ts
@@ -63,6 +63,13 @@ export function getCommand() {
                 long: "locales",
                 description: "Locales to include as columns, comma-separated. Example: Spanish,French",
             }),
+            programId: option({
+                type: optional(string),
+                long: "program-id",
+                description:
+                    "Scope the export to a program's metadata dependency export " +
+                    "(/api/programs/{id}/metadata) instead of the whole instance",
+            }),
             includeData: flag({
                 long: "include-data",
                 description:
@@ -89,6 +96,7 @@ export function getCommand() {
                 models: args.models,
                 locales: parseList(args.locales),
                 includeData: args.includeData,
+                programId: args.programId,
             });
         },
     });


### PR DESCRIPTION
Closes https://app.clickup.com/t/4528615/869dc4guz?comment=90120236273934

Follow-up to #101, adding two capabilities to `translations to-spreadsheet`.

## Changes

- **`--program-id` filter.** When set, objects are taken from that program's metadata dependency export (`/api/programs/{id}/metadata`) instead of the whole instance, so each generated spreadsheet is scoped to a single program.
- **Short locale references.** `--locales` now matches by exact base name first, then by substring, so `Sotho` resolves to `Southern Sotho (Lesotho)`. A reference matching more than one locale is ambiguous and errors; no match warns and is skipped (as before).
- **Suffix-stripped column headers.** The resolved locale's ` (...)` qualifier is dropped from the column header (`formName: Southern Sotho` instead of `formName: Southern Sotho (Lesotho)`). This also fixes the round-trip: `from-spreadsheet` matches headers against suffix-stripped DB names, so previously any locale with a `(country)` suffix would not re-import.

## Test plan

- Unit tests added/updated in `ExportTranslationsUseCase.spec.ts` (short/substring match, ambiguity error, stripped header, program-scoped fetch). `yarn vitest run` green; `tsc --noEmit` clean.
- Verified end-to-end against a live instance: program-scoped export produces one program's objects; `Sotho` → `Southern Sotho` header; and a `from-spreadsheet --post` round-trip added a `st_LS` translation while preserving existing ones.