### PR TITLE
[Feature] Add start/end-date, descendants and skip-metadata to export programs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Notes:
 Export a program with all its associated metadata and data (events, enrollments, tracked entities).
 
 The data can be filtered by:
-- Organization Unit via the `--orgunits-ids` option. If `--descendants` is used, the included orgUnits will be the specified and its descendants.
+- Organization Unit via the `--orgunits-ids` option. If `--descendants` is used, the included orgUnits will be the specified and its descendants. Note that if no `--orgunits-ids` is provided the `ouMode` will be `ALL` and the `--descendants` option will be redundant.
 - The `lastUpdated` property using the `--start-date` and/or `--end-date` options.
 
 The metadata export can be skipped via the `--skip-metadata`option.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Notes:
 
 Export a program with all its associated metadata and data (events, enrollments, tracked entities).
 
+The data can be filtered by:
+- Organization Unit via the `--orgunits-ids` option. If `--descendants` is used, the included orgUnits will be the specified and its descendants.
+- The `lastUpdated` property using the `--start-date` and/or `--end-date` options.
+
+The metadata export can be skipped via the `--skip-metadata`option.
+
+
 ```shell
 $ yarn start programs export --url='http://USER:PASSWORD@HOST:PORT' \
   --programs-ids=kX2GpLIa75l,kpNc7KvydVz programs.json

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ The data can be filtered by:
 - Organization Unit via the `--orgunits-ids` option. If `--descendants` is used, the included orgUnits will be the specified and its descendants. Note that if no `--orgunits-ids` is provided the `ouMode` will be `ALL` and the `--descendants` option will be redundant.
 - The `lastUpdated` property using the `--start-date` and/or `--end-date` options.
 
-The metadata export can be skipped via the `--skip-metadata`option.
+The metadata export can be skipped via the `--skip-metadata` option.
+
+The login details can be either provided as `--url='http://USER:PASSWORD@HOST:PORT'` or `--url='http://HOST:PORT' --auth='USER:PASSWORD'`. The `--auth` option is useful with complex passwords that can cause errors when used in the `--url` only approach.
 
 
 ```shell

--- a/src/data/D2Tracker.ts
+++ b/src/data/D2Tracker.ts
@@ -76,12 +76,14 @@ export class D2Tracker {
             orgUnitIds: string[] | undefined;
             trackedEntity?: string | undefined;
             children?: boolean;
+            startDate?: string;
+            endDate?: string;
         }
     ): Promise<Array<Mapping[Key][number]>> {
         type Output = Array<Mapping[Key][number]>;
 
         const output: Output = [];
-        const { programIds, orgUnitIds, trackedEntity } = options;
+        const { programIds, orgUnitIds, trackedEntity, startDate, endDate } = options;
 
         for (const programId of programIds) {
             let page = 1;
@@ -101,6 +103,8 @@ export class D2Tracker {
                     fields: { $all: true } as const,
                     program: programId,
                     trackedEntity,
+                    updatedAfter: startDate,
+                    updatedBefore: endDate,
                 };
 
                 const { tracker } = this.api;

--- a/src/data/D2Tracker.ts
+++ b/src/data/D2Tracker.ts
@@ -98,6 +98,7 @@ export class D2Tracker {
                 const apiOptions = {
                     page: page,
                     pageSize: pageSize,
+                    // NOTE: For 2.41+ ouMode is orgUnitMode
                     ouMode: ouMode as typeof ouMode,
                     orgUnit: orgUnitIds?.join(";"),
                     fields: { $all: true } as const,

--- a/src/data/ProgramsD2Repository.ts
+++ b/src/data/ProgramsD2Repository.ts
@@ -148,7 +148,7 @@ export class ProgramsD2Repository implements ProgramsRepository {
 }
 
 interface D2ProgramExport {
-    metadata: object;
+    metadata?: object;
     data: D2ProgramData;
 }
 

--- a/src/data/ProgramsD2Repository.ts
+++ b/src/data/ProgramsD2Repository.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { Async } from "domain/entities/Async";
 import { Id } from "domain/entities/Base";
 import { ProgramExport } from "domain/entities/ProgramExport";
-import { ProgramsRepository, RunRulesOptions } from "domain/repositories/ProgramsRepository";
+import { ProgramsRepository, RunRulesOptions, ExportOptions } from "domain/repositories/ProgramsRepository";
 import {
     D2Api,
     D2TrackedEntityInstanceToPost,
@@ -59,11 +59,18 @@ export class ProgramsD2Repository implements ProgramsRepository {
         return programs;
     }
 
-    async export(options: { ids: Id[]; orgUnitIds: Id[] | undefined }): Async<ProgramExport> {
-        const { ids: programIds, orgUnitIds } = options;
-        const metadata = await this.getMetadata(programIds);
+    async export(options: ExportOptions): Async<ProgramExport> {
+        const {
+            ids: programIds,
+            orgUnitIds,
+            descendants: children,
+            skipMetadata,
+            startDate,
+            endDate,
+        } = options;
+        const metadata = skipMetadata ? undefined : await this.getMetadata(programIds);
 
-        const getOptions = { programIds, orgUnitIds };
+        const getOptions = { programIds, orgUnitIds, children, startDate, endDate };
         const events = await this.d2Tracker.getFromTracker("events", getOptions);
         const enrollments = await this.d2Tracker.getFromTracker("enrollments", getOptions);
         const trackedEntities = await this.d2Tracker.getFromTracker("trackedEntities", getOptions);
@@ -75,7 +82,7 @@ export class ProgramsD2Repository implements ProgramsRepository {
         }));
 
         return {
-            metadata,
+            metadata: metadata,
             data: {
                 events: events,
                 enrollments: enrollments,
@@ -114,8 +121,10 @@ export class ProgramsD2Repository implements ProgramsRepository {
     }
 
     async import(programExport: D2ProgramExport): Async<void> {
-        const metadataRes = await runMetadata(this.api.metadata.post(programExport.metadata));
-        log.info(`Metadata import status: ${metadataRes.status}`);
+        if (programExport.metadata) {
+            const metadataRes = await runMetadata(this.api.metadata.post(programExport.metadata));
+            log.info(`Metadata import status: ${metadataRes.status}`);
+        }
 
         const { events, enrollments, trackedEntities } = programExport.data;
         const teisById = _.keyBy(trackedEntities, tei => tei.trackedEntity);

--- a/src/domain/entities/ProgramExport.ts
+++ b/src/domain/entities/ProgramExport.ts
@@ -1,5 +1,5 @@
 export interface ProgramExport {
-    metadata: object;
+    metadata?: object;
     data: ProgramData;
 }
 

--- a/src/domain/repositories/ProgramsRepository.ts
+++ b/src/domain/repositories/ProgramsRepository.ts
@@ -6,7 +6,7 @@ import { ProgramExport } from "domain/entities/ProgramExport";
 
 export interface ProgramsRepository {
     get(options: { ids?: Id[]; programTypes?: ProgramType[] }): Async<Program[]>;
-    export(options: { ids: Id[] }): Async<ProgramExport>;
+    export(options: ExportOptions): Async<ProgramExport>;
     import(programExport: ProgramExport): Async<void>;
     runRules(options: RunRulesOptions): Async<void>;
     getAppUrl(options: { programId: Id; orgUnitId: Id }): string;
@@ -24,4 +24,13 @@ export interface RunRulesOptions {
     post: boolean;
     payloadPath?: string;
     backup: boolean;
+}
+
+export interface ExportOptions {
+    ids: Id[];
+    orgUnitIds?: Id[];
+    startDate?: Timestamp;
+    endDate?: Timestamp;
+    descendants?: boolean;
+    skipMetadata?: boolean;
 }

--- a/src/domain/usecases/ExportProgramsUseCase.ts
+++ b/src/domain/usecases/ExportProgramsUseCase.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { Async } from "domain/entities/Async";
 import { Id } from "domain/entities/Base";
+import { Timestamp } from "domain/entities/Date";
 import { ProgramsRepository } from "domain/repositories/ProgramsRepository";
 import log from "utils/log";
 
@@ -20,4 +21,8 @@ interface ExportProgramsOptions {
     ids: Id[];
     outputFile: string;
     orgUnitIds?: Id[];
+    startDate?: Timestamp;
+    endDate?: Timestamp;
+    descendants?: boolean;
+    skipMetadata?: boolean;
 }

--- a/src/scripts/commands/programs.ts
+++ b/src/scripts/commands/programs.ts
@@ -45,16 +45,38 @@ const programIdsOptions = option({
     description: "List of program (comma-separated)",
 });
 
+const startDateArg = option({
+    type: optional(string),
+    long: "start-date",
+    description: "Start date",
+});
+
+const endDateArg = option({
+    type: optional(string),
+    long: "end-date",
+    description: "End date",
+});
+
 const exportCmd = command({
     name: "export",
     description: "Export program metadata and data (events, enrollments, TEIs)",
     args: {
-        url: getApiUrlOption(),
+        ...getApiUrlOptions(),
         programIds: programIdsOptions,
         orgUnitIds: option({
             type: optional(StringsSeparatedByCommas),
             long: "orgunits-ids",
             description: "List of organisation units (comma-separated)",
+        }),
+        startDate: startDateArg,
+        endDate: endDateArg,
+        descendants: flag({
+            long: "descendants",
+            description: "Include descendants of the specified organisation units",
+        }),
+        skipMetadata: flag({
+            long: "skip-metadata",
+            description: "Skip metadata export",
         }),
         outputFile: positional({
             type: string,
@@ -63,7 +85,7 @@ const exportCmd = command({
     },
     handler: async args => {
         if (_.isEmpty(args.programIds)) throw new Error("Missing program IDs");
-        const api = getD2Api(args.url);
+        const api = getD2ApiFromArgs(args);
         const programsRepository = new ProgramsD2Repository(api);
 
         new ExportProgramsUseCase(programsRepository).execute({
@@ -77,14 +99,14 @@ const importCmd = command({
     name: "import",
     description: "Import program metadata and data (events, enrollments, TEIs)",
     args: {
-        url: getApiUrlOption(),
+        ...getApiUrlOptions(),
         inputFile: positional({
             type: string,
             description: "Input file (JSON)",
         }),
     },
     handler: async args => {
-        const api = getD2Api(args.url);
+        const api = getD2ApiFromArgs(args);
         const programsRepository = new ProgramsD2Repository(api);
         new ImportProgramsUseCase(programsRepository).execute({
             inputFile: args.inputFile,
@@ -310,18 +332,6 @@ const orgUnitModeArg = option({
     type: optional(choiceOf(orgUnitModes)),
     long: "org-unit-mode",
     description: `Orgunit mode: ${orgUnitModes.join(", ")}`,
-});
-
-const startDateArg = option({
-    type: optional(string),
-    long: "start-date",
-    description: "Start date",
-});
-
-const endDateArg = option({
-    type: optional(string),
-    long: "end-date",
-    description: "End date",
 });
 
 const dataElementIdsInclude = option({


### PR DESCRIPTION
### :pushpin: References

Issue: [[49] Migrate event data for SKERU](https://app.clickup.com/t/4528615/869edk1gd)

### :memo: Implementation

- Update export programs script to allow the data to be filtered by the `lastUpdated` property using the `--start-date` and/or `--end-date` options.

- Added the  `--descendants` option, is its used, the included orgUnits will be the specified by `--orgunits-ids` and its descendants.

- The metadata export can be skipped via the `--skip-metadata`option.

- Change program import to allow importing without metadata.